### PR TITLE
Move xs-opam repo from github.com/lindig to github.com/xapi-project

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 
 DATE    := $(shell printf '%x' `date +%s`)
 RELEASE := $(shell git describe --always)
-VERSION := 0.0.$(DATE)
+VERSION := 0.1.$(DATE)
 
 TOP	:= $(PWD)
 SRC	:= "$(TOP)/build/src"
@@ -33,10 +33,14 @@ build:
 # generate spec files
 spec:
 	awk '/^#/ {next}; /http/ { printf "Source%03d: %s\n", ++n, $$2}' sources.txt > sources.spec
-	sed -e '/^# sources.spec/r sources.spec' \
-		-e 's/@VERSION@/$(VERSION)/' xs-opam-src.in > xs-opam-src.spec
+	sed 	-e '/^# sources.spec/r sources.spec'	\
+		-e 's/@VERSION@/$(VERSION)/' 		\
+		-e 's/@RELEASE@/$(RELEASE)/' 		\
+		xs-opam-src.in > xs-opam-src.spec
 	rm sources.spec
-	sed -e 's/@VERSION@/$(VERSION)/' xs-opam-repo.in > xs-opam-repo.spec
+	sed 	-e 's/@VERSION@/$(VERSION)/' 		\
+		-e 's/@RELEASE@/$(RELEASE)/' 		\
+		xs-opam-repo.in > xs-opam-repo.spec
 
 # download all archives but skip those that are already present
 download: build

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ implemented in OCaml. It can be used in two ways:
   remote Opam repository:
 
   ```
-  opam repo add xs-opam https://github.com/lindig/xs-opam.git
+  opam repo add xs-opam https://github.com/xapi-project/xs-opam.git
   ```
 
 * For building and packaging this repo an an RPM.  Running

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ implemented in OCaml. It can be used in two ways:
   opam repo add xs-opam https://github.com/xapi-project/xs-opam.git
   ```
 
-* For building and packaging this repo an an RPM.  Running
+* For building and packaging this repo as an RPM.  Running
 
   ```
   make spec

--- a/xs-opam-repo.in
+++ b/xs-opam-repo.in
@@ -3,7 +3,8 @@ Version: @VERSION@
 Release: 1%{?dist}
 Summary: Build and install OCaml libraries from Opam repository
 License: Various
-URL: http://github.com/lindig/xs-opam
+URL: http://github.com/xapi-project/xs-opam
+# Git commit @RELEASE@
 
 AutoReqProv: no
 BuildRequires: xs-opam-src = %{version}
@@ -68,5 +69,8 @@ rm -rf %{buildroot}/usr/lib/opamroot/system/build/*
 /usr/lib/opamroot
 
 %changelog
+* Thu Feb 02 2017 Christian Lindig <christian.lindig@citrix.com> - 0.1.1-1
+- This file is auto-generated and the changelog currently does not
+  reflect the changes.
 * Tue Dec 20 2016 Christian Lindig <christian.lindig@citrix.com> - 0.0.1-1
 - Initial version

--- a/xs-opam-src.in
+++ b/xs-opam-src.in
@@ -3,10 +3,11 @@ Version: @VERSION@
 Release: 1%{?dist}
 Summary: Opam repository
 License: Various
-URL: http://github.com/lindig/xs-opam
+URL: http://github.com/xapi-project/xs-opam
+# Git commit @RELEASE@
 AutoReqProv: no
 
-Source000: https://github.com/lindig/xs-opam/archive/master/xs-opam-master.tar.gz
+Source000: https://github.com/xapi-project/xs-opam/archive/master/xs-opam-master.tar.gz
 # sources.spec
 
 BuildRequires: opam
@@ -45,6 +46,9 @@ chmod 777 %{buildroot}/usr/lib/opamroot
 %attr(777, root, wheel) /usr/lib/opamroot
 
 %changelog
+* Thu Feb 02 2017 Christian Lindig <christian.lindig@citrix.com> - 0.1.1-1
+- This file is auto-generated and the changelog currently does not
+  reflect the changes.
 * Tue Dec 20 2016 Christian Lindig <christian.lindig@citrix.com> - 0.0.1-1 
 - Initial version
 


### PR DESCRIPTION
* Update README
* Update URLs pointing to repository
* Add current commit hash as comment to auto-generated spec files

Signed-off-by: Christian <christian.lindig@citrix.com>