### PR TITLE
Add missing .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.gitarchive-info export-subst


### PR DESCRIPTION
This file is required to make expansion of .gitarchive-info work.

Signed-off-by: Christian <christian.lindig@citrix.com>