### PR TITLE
Revert "travis: add missing library to XS - xapi-netdev"

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -35,7 +35,6 @@ shared-block-ring
 xapi-backtrace
 xapi-idl
 xapi-inventory
-xapi-netdev
 xapi-rrd
 xapi-stdext
 xen-api-client


### PR DESCRIPTION
This reverts commit b80f82881f5bacf2d40d824658ea8ecaf34c82d9.
xapi-netdev requires systemd, but this is not whitelisted to be
installed in travis, making the install step fail.

Signed-off-by: Marcello Seri <marcello.seri@citrix.com>