### PR TITLE
Sync opam file of message-switch

### DIFF
--- a/packages/xs-extra/message-switch.master/opam
+++ b/packages/xs-extra/message-switch.master/opam
@@ -16,7 +16,7 @@ remove: [
 ]
 depends: [
   "ocamlfind"
-  "cohttp"
+  "cohttp" {>= "0.15.0" }
   "rpc"
   "sexplib"
   "ppx_sexp_conv"
@@ -25,7 +25,7 @@ depends: [
   "uri"
   "re"
   "mtime"
-  "mirage-block-unix"
+  "mirage-block-unix" {>= "2.4.0"}
   "shared-block-ring"
   "cmdliner"
   "ssl"

--- a/packages/xs-extra/message-switch.master/opam
+++ b/packages/xs-extra/message-switch.master/opam
@@ -1,8 +1,14 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "xen-api@lists.xen.org"
+authors: [ "xen-api@lists.xen.org" ]
+homepage: "https://github.com/xapi-project/message-switch"
+bug-reports: "https://github.com/xapi-project/message-switch/issues"
+dev-repo: "git://github.com/xapi-project/message-switch"
 build: [
   ["./configure" "--bindir" "%{bin}%"]
   [make]
+]
+install: [
   [make "install"]
 ]
 remove: [


### PR DESCRIPTION
After https://github.com/xapi-project/message-switch/pull/29, update the `opam` file here to match the one in its source repository, at the HEAD of the master branch.