### PR TITLE
Add upstream-extra to the xs-opam repository

### DIFF
--- a/packages/upstream-extra/alcotest.0.7.2/descr
+++ b/packages/upstream-extra/alcotest.0.7.2/descr
@@ -1,0 +1,11 @@
+Alcotest is a lightweight and colourful test framework.
+
+Alcotest exposes simple interface to perform unit tests. It exposes
+a simple `TESTABLE` module type, a `check` function to assert test
+predicates and a `run` function to perform a list of `unit -> unit`
+test callbacks.
+
+Alcotest provides a quiet and colorful output where only faulty runs
+are fully displayed at the end of the run (with the full logs ready to
+inspect), with a simple (yet expressive) query language to select the
+tests to run.

--- a/packages/upstream-extra/alcotest.0.7.2/opam
+++ b/packages/upstream-extra/alcotest.0.7.2/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+maintainer: "thomas@gazagnaire.org"
+authors:     "Thomas Gazagnaire"
+homepage:    "https://github.com/mirage/alcotest/"
+dev-repo:    "https://github.com/mirage/alcotest.git"
+bug-reports: "https://github.com/mirage/alcotest/issues/"
+license:     "ISC"
+doc:         "https://mirage.github.io/alcotest/"
+
+build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"]
+build-test: [
+  ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true"]
+  ["ocaml" "pkg/pkg.ml" "test" ]
+]
+depends: [
+  "ocamlfind"  {build}
+  "ocamlbuild" {build}
+  "topkg"      {build}
+  "fmt"
+  "astring"
+  "result"
+  "cmdliner"
+]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/upstream-extra/alcotest.0.7.2/url
+++ b/packages/upstream-extra/alcotest.0.7.2/url
@@ -1,0 +1,1 @@
+archive: "https://github.com/mirage/alcotest/archive/0.7.2.tar.gz"

--- a/travis.sh
+++ b/travis.sh
@@ -17,7 +17,7 @@ sh  .travis-ocaml.sh
 # list of packages -- excluding some that can't be installed on Travis
 pkg()
 {
-	find packages/upstream -maxdepth 1 -mindepth 1 -type d \
+	find packages/upstream packages/upstream-extra -maxdepth 1 -mindepth 1 -type d \
 	| awk -F/ '{print $NF}' \
 	| egrep -v '^(systemd)'
 }


### PR DESCRIPTION
And introduce alcotest, necessary to unlock the test pass of the travis builds in some of the other packages repositories.