### PR TITLE
upstream-extra: introduce ocveralls for coverage builds

### DIFF
--- a/packages/upstream-extra/ocveralls.0.3.4/descr
+++ b/packages/upstream-extra/ocveralls.0.3.4/descr
@@ -1,0 +1,3 @@
+Generate JSON for http://coveralls.io from bisect code coverage data.
+
+Also support automatic upload of generated data.

--- a/packages/upstream-extra/ocveralls.0.3.4/findlib
+++ b/packages/upstream-extra/ocveralls.0.3.4/findlib
@@ -1,0 +1,1 @@
+ocveralls

--- a/packages/upstream-extra/ocveralls.0.3.4/opam
+++ b/packages/upstream-extra/ocveralls.0.3.4/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+available:    [ ocaml-version >= "4.02.0" ]
+name:         "ocveralls"
+version:      "0.3.4"
+maintainer:   "Julien Sagot ju.sagot@gmail.com"
+author:       "Julien Sagot ju.sagot@gmail.com"
+license:      "GPL v3.0"
+homepage:     "https://github.com/sagotch/ocveralls"
+bug-reports:  "https://github.com/sagotch/ocveralls/issues"
+dev-repo:     "https://github.com/sagotch/ocveralls.git"
+
+build:   [ make "build" ]
+install: [ make "bindir=%{bin}%" "install" ]
+remove:  [ "rm" "-f" "%{bin}%/ocveralls" ]
+
+depends: [
+  "ocamlfind" { build }
+  "ezjsonm" { build & >="0.4.0" }
+  ("bisect" | "bisect_ppx" { build })
+]

--- a/packages/upstream-extra/ocveralls.0.3.4/url
+++ b/packages/upstream-extra/ocveralls.0.3.4/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/sagotch/ocveralls/archive/3.3.4.tar.gz"
+checksum: "5ba0aee3781c7c85e56f9525a56a182f"


### PR DESCRIPTION
The version appearing in the URL is 3.3.4, however this is the URL used
in the official opam repository, the hash is the correct one and the
content is the correct one. The original can be seen here: 
https://github.com/ocaml/opam-repository/tree/master/packages/ocveralls/ocveralls.0.3.4

Signed-off-by: Marcello Seri <marcello.seri@citrix.com>