### PR TITLE
xapi-networkd: fix install/remove

### DIFF
--- a/packages/xs-extra/xapi-networkd.master/opam
+++ b/packages/xs-extra/xapi-networkd.master/opam
@@ -4,9 +4,9 @@ authors: "jonathan.ludlam@eu.citrix.com"
 homepage: "https://github.com/xapi-project/xcp-networkd"
 build: [
   [make]
-  [make "install" "BINDIR=%{bin}%" "SBINDIR=%{bin}%" "LIBEXECDIR=%{bin}%" "SCRIPTSDIR=%{bin}%" "ETCDIR=%{prefix}%/etc"]
+  [make "install" "BINDIR=%{bin}%" "SBINDIR=%{bin}%" "LIBEXECDIR=%{bin}%" "SCRIPTSDIR=%{bin}%" "ETCDIR=%{prefix}%/etc" "MANDIR=%{man}"]
 ]
-remove: [make "uninstall" "BINDIR=%{bin}%" "SBINDIR=%{bin}%" "LIBEXECDIR=%{bin}%" "SCRIPTSDIR=%{bin}%" "ETCDIR=%{prefix}%/etc"]
+remove: [make "uninstall" "BINDIR=%{bin}%" "SBINDIR=%{bin}%" "LIBEXECDIR=%{bin}%" "SCRIPTSDIR=%{bin}%" "ETCDIR=%{prefix}%/etc" "MANDIR=%{man}"]
 depends: [
   "bisect_ppx"
   "netlink"


### PR DESCRIPTION
Passing the correct `MANDIR` should fix the build when we compile the extra packages. :crossed_fingers: 

Signed-off-by: Marcello Seri <marcello.seri@citrix.com>