### PR TITLE
Update lwt constraint on `xs` packages

### DIFF
--- a/packages/xs/nbd.2.1.2/opam
+++ b/packages/xs/nbd.2.1.2/opam
@@ -27,7 +27,7 @@ depends: [
   "ounit" {test}
   "ocamlfind" {build}
   "ppx_tools" {build}
-  "lwt"
+  "lwt" { < "3.0.0" }
   "cstruct" {>= "1.9.0"}
   "cmdliner"
   "sexplib"

--- a/packages/xs/xen-api-client.0.9.14/opam
+++ b/packages/xs/xen-api-client.0.9.14/opam
@@ -22,7 +22,7 @@ remove: [["ocamlfind" "remove" "xen-api-client"]]
 depends: [
   "ocamlfind" {build}
   "oasis"     {build}
-  "lwt" {>= "2.4.3"}
+  "lwt" {>= "2.4.3" & < "3.0.0"}
   "cstruct" {>= "1.0.1"}
   "ssl"
   "ounit"

--- a/packages/xs/xenctrl.dummy/opam
+++ b/packages/xs/xenctrl.dummy/opam
@@ -15,6 +15,6 @@ remove: [
 ]
 depends: [
   "ocamlfind"
-  "lwt"
+  "lwt" {< "3.0.0"}
   "cmdliner"
 ]


### PR DESCRIPTION
This prevents `xenctrl.dummy` to be chosen in place of `xenctrl.master` when `lwt 3.0.0` is already installed. 
It should resolve an issue arisen from https://github.com/xapi-project/dev-vm/pull/2 and avoid the need to pin lwt by hand.

Signed-off-by: Marcello Seri <marcello.seri@citrix.com>