### PR TITLE
Update README

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN sudo apt-get update \
 
 RUN opam update \
     && opam upgrade -y \
-    && opam install merlin ocp-browser ocp-indent ocp-index depext user-setup utop \
+    && opam pin add lwt 2.7.1 -y \
+    && opam install merlin ocp-browser ocp-indent ocp-index depext user-setup utop -y \
     && opam user-setup install
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,11 @@ You can add this Git repository as a remote OPAM repository:
 
   ```
   opam repo add xs-opam https://github.com/xapi-project/xs-opam.git
+  opam pin add lwt 2.7.1
   ```
+
+Due to constraints missing from old libraries, pinning the `lwt` package
+is necessary for certain configurations.
 
 ## Layout of This Repository
 


### PR DESCRIPTION
mentioning the necessity of pinning `lwt` to version `2.7.1` on certain setups. And update the `Dockerfile` accordingly