### PR TITLE
Revert "remove optcomp 1.6" - required by xenopsd

### DIFF
--- a/packages/upstream/optcomp.1.6/descr
+++ b/packages/upstream/optcomp.1.6/descr
@@ -1,0 +1,1 @@
+Optional compilation with cpp-like directives

--- a/packages/upstream/optcomp.1.6/findlib
+++ b/packages/upstream/optcomp.1.6/findlib
@@ -1,0 +1,1 @@
+optcomp

--- a/packages/upstream/optcomp.1.6/opam
+++ b/packages/upstream/optcomp.1.6/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+maintainer: "jeremie@dimino.org"
+authors: ["Jérémie Dimino"]
+homepage: "https://github.com/diml/optcomp"
+license: "BSD3"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+build-doc: [["ocaml" "setup.ml" "-doc"]]
+remove: [
+  ["ocamlfind" "remove" "optcomp"]
+  ["rm" "%{bin}%/optcomp-o"]
+  ["rm" "%{bin}%/optcomp-r"]
+]
+depends: [
+  "ocamlfind"
+  "camlp4"
+  "ocamlbuild" {build}
+]
+dev-repo: "git://github.com/diml/optcomp"
+available: ocaml-version >= "3.12"
+install: [make "install"]

--- a/packages/upstream/optcomp.1.6/url
+++ b/packages/upstream/optcomp.1.6/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/diml/optcomp/archive/1.6.tar.gz"
+checksum: "d3587244dba1b8b10f24d0b60a8c700d"


### PR DESCRIPTION
This reverts commit 81b2f8265da39d8ac60c6e5f274102456f3f5aca.

The package is required by xenopsd.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>