### PR TITLE
Add xen-api-sdk to xs-opam

### DIFF
--- a/packages/xs-extra/xen-api-sdk.master/descr
+++ b/packages/xs-extra/xen-api-sdk.master/descr
@@ -1,0 +1,1 @@
+Xen API SDK generation code.

--- a/packages/xs-extra/xen-api-sdk.master/opam
+++ b/packages/xs-extra/xen-api-sdk.master/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+maintainer: "xen-api@lists.xen.org"
+authors: [ "xen-api@lists.xen.org" ]
+homepage: "https://github.com/xapi-project/xen-api-sdk"
+bug-reports: "https://github.com/xapi-project/xen-api-sdk/issues"
+dev-repo: "https://github.com/xapi-project/xen-api-sdk.git"
+tags: [ "org:xapi-project" ]
+build: [
+  ["oasis" "setup"]
+  ["ocaml" "setup.ml" "-configure"]
+  ["ocaml" "setup.ml" "-build"]
+]
+depends: [
+  "xapi"
+  "mustache"
+]

--- a/packages/xs-extra/xen-api-sdk.master/url
+++ b/packages/xs-extra/xen-api-sdk.master/url
@@ -1,0 +1,1 @@
+archive: "https://github.com/xapi-project/xen-api-sdk/archive/master.tar.gz"


### PR DESCRIPTION
This will help us notice when we break the SDK generation code.

I already have a fork of `xen-api-sdk` with this `opam` file, and a working Travis build: https://travis-ci.org/gaborigloi/xen-api-sdk/builds/233636569

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>