### PR TITLE
Set cstruct < 3.0.0 on all our packages

### DIFF
--- a/packages/xs-extra/vhd-tool.master/opam
+++ b/packages/xs-extra/vhd-tool.master/opam
@@ -18,7 +18,7 @@ depends: [
   "ocamlfind" {build}
   "cmdliner"
   "cohttp" {>="0.12.0" & < "0.22.0"}
-  "cstruct" {>= "1.0.1"}
+  "cstruct" {>= "1.0.1" & < "3.0.0"}
   "io-page-unix"
   "lwt" {>= "2.4.3" & < "3.0.0"}
   "nbd" {>= "1.0.1" & < "3.0.0"}

--- a/packages/xs-extra/xapi-nbd.master/opam
+++ b/packages/xs-extra/xapi-nbd.master/opam
@@ -19,7 +19,7 @@ depends: [
   "oasis"
   "ocamlfind"
   "lwt" {< "3.0.0"}
-  "cstruct" {> "1.0.0"}
+  "cstruct" {> "1.0.0" & < "3.0.0"}
   "cmdliner"
   "sexplib"
   "mirage-block-unix"

--- a/packages/xs-extra/xapi-rrd-transport.master/opam
+++ b/packages/xs-extra/xapi-rrd-transport.master/opam
@@ -12,7 +12,7 @@ install: [
 remove: [make "PREFIX=%{prefix}%" "uninstall"]
 depends: [
   "cmdliner"
-  "cstruct"
+  "cstruct" {< "3.0.0"}
   "crc"
   "xapi-idl"
   "xapi-rrd"

--- a/packages/xs/crc.1.0.0/opam
+++ b/packages/xs/crc.1.0.0/opam
@@ -19,7 +19,7 @@ remove: [
   [make "PREFIX=%{prefix}%" "uninstall"]
 ]
 depends: [
-  "cstruct" {>= "1.0.1"}
+  "cstruct" {>= "1.0.1" & < "3.0.0"}
   "ounit" {test}
   "oasis" {build}
   "ocamlbuild" {build}

--- a/packages/xs/nbd.2.1.3/opam
+++ b/packages/xs/nbd.2.1.3/opam
@@ -28,7 +28,7 @@ depends: [
   "ocamlfind" {build}
   "ppx_tools" {build}
   "lwt"
-  "cstruct" {>= "1.9.0"}
+  "cstruct" {>= "1.9.0" & < "3.0.0"}
   "cmdliner"
   "sexplib"
   "mirage-block-unix"

--- a/packages/xs/xen-api-client.0.9.14/opam
+++ b/packages/xs/xen-api-client.0.9.14/opam
@@ -23,7 +23,7 @@ depends: [
   "ocamlfind" {build}
   "oasis"     {build}
   "lwt" {>= "2.4.3"}
-  "cstruct" {>= "1.0.1"}
+  "cstruct" {>= "1.0.1" & < "3.0.0"}
   "ssl"
   "ounit"
   "cohttp" {>= "0.12.0"}


### PR DESCRIPTION
To fix the build against the upstream opam.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>