### PR TITLE
Add xen-gnt < 3.0.0 bound to all our packages

### DIFF
--- a/packages/xs-extra/xapi-rrd-transport.master/opam
+++ b/packages/xs-extra/xapi-rrd-transport.master/opam
@@ -16,5 +16,5 @@ depends: [
   "crc"
   "xapi-idl"
   "xapi-rrd"
-  "xen-gnt"
+  "xen-gnt" {< "3.0.0"}
 ]

--- a/packages/xs-extra/xapi-rrdd.master/opam
+++ b/packages/xs-extra/xapi-rrdd.master/opam
@@ -27,7 +27,7 @@ depends: [
   "xapi-xenops"
   "io-page"
   "inotify"
-  "xen-gnt"
+  "xen-gnt" {< "3.0.0"}
   "xapi-rrd-transport"
   "oclock"
   "ounit"


### PR DESCRIPTION
Version 3.0.0 has been split into two OPAM and ocamlfind packages.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>