### PR TITLE
update opam after coverage build changes

### DIFF
--- a/packages/xs-extra/xapi-xenopsd.master/opam
+++ b/packages/xs-extra/xapi-xenopsd.master/opam
@@ -3,16 +3,15 @@ maintainer: "xen-api@lists.xen.org"
 authors: "xen-api@lists.xen.org"
 homepage: "https://github.com/xapi-project/xenopsd"
 build: [
-	["oasis" "setup"]
 	["./configure"]
 	[make]
 ]
 install: [
- 	["ocaml" "setup.ml" "-install"]
+ 	["./setup.bin" "-install"]
 ]
 remove: [
-        ["oasis" "setup"]
-        ["ocaml" "setup.ml" "-uninstall"]
+        ["make" "setup.data"]
+        ["./setup.bin" "-uninstall"]
         ["ocamlfind" "remove" "xenopsd"]
 ]
 depends: [


### PR DESCRIPTION
See https://github.com/xapi-project/xenopsd/pull/350

Thanks to @gaborigloi for the reminder and help with the `remove` rule.