### PR TITLE
cohttp: add conduit < v1.0.0 upper bound

### DIFF
--- a/packages/upstream/cohttp.0.21.1/opam
+++ b/packages/upstream/cohttp.0.21.1/opam
@@ -32,7 +32,7 @@ depends: [
   "uri" {>= "1.9.0"}
   "fieldslib"
   "sexplib"
-  "conduit" {>= "0.14.0"}
+  "conduit" {>= "0.14.0" & < "v1.0.0"}
   "ppx_fields_conv"
   "ppx_deriving" {build}
   "ppx_sexp_conv"


### PR DESCRIPTION
To fix the build when using xs-opam as an extra remote.
In conduit v1.0.0 the package has been split into multiple packages.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>