### PR TITLE
Update constraints for cohttp from upstream

### DIFF
--- a/packages/upstream/cohttp.0.21.1/opam
+++ b/packages/upstream/cohttp.0.21.1/opam
@@ -32,7 +32,7 @@ depends: [
   "uri" {>= "1.9.0"}
   "fieldslib"
   "sexplib"
-  "conduit" {>= "0.14.0" & < "v1.0.0"}
+  "conduit" {>= "0.14.0" & <"0.16.0"}
   "ppx_fields_conv"
   "ppx_deriving" {build}
   "ppx_sexp_conv"
@@ -47,5 +47,6 @@ conflicts: [
   "async" {< "113.24.00"}
   "lwt" {< "2.5.0"}
   "js_of_ocaml" {< "2.8"}
+  "js_of_ocaml" {>= "3.0"}
 ]
 available: [ocaml-version >= "4.01.0"]


### PR DESCRIPTION
cohttp fails to build with conduit 1.0.0 otherwise.
There seems to have been a typo in the version constraint in our version, 1.0.0 < v1.0.0, so it didn't actually prevent 1.0 from getting installed.

Signed-off-by: Edwin Török <edvin.torok@citrix.com>