### PR TITLE
drop oasis test-only dependencies

### DIFF
--- a/packages/upstream/oasis.0.4.10/opam
+++ b/packages/upstream/oasis.0.4.10/opam
@@ -13,24 +13,13 @@ install: ["ocaml" "setup.ml" "-install"]
 remove: [
   ["ocaml" "%{etc}%/oasis/setup.ml" "-C" "%{etc}%/oasis" "-uninstall"]
 ]
-build-test: [
-  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
-  ["ocaml" "setup.ml" "-build"]
-  ["ocaml" "setup.ml" "-test"]
-]
 build-doc: [ "ocaml" "setup.ml" "-doc" ]
 depends: [
   "base-unix"
-  "camlp4" {test}
-  "expect" {test & >= "0.0.4"}
-  "fileutils" {test & >= "0.4.2"}
   "ocamlbuild"
   "ocamlfind" {>= "1.3.1"}
   "ocamlify" {build}
   "ocamlmod" {build}
-  "omake" {test}
-  "ounit" {test & >= "2.0.0"}
-  "pcre" {test}
 ]
 depopts: [
   "benchmark"


### PR DESCRIPTION
We do not run the tests for oasis, and it would need several packages to be
added to xs-opam to make BASE_REMOTE Travis testing work
(which tries to install the test-only dependencies too).
