### PR TITLE
xapi: introduce new packages after xapi port to jbuild

### DIFF
--- a/packages/xs-extra/vncproxy.master/opam
+++ b/packages/xs-extra/vncproxy.master/opam
@@ -12,5 +12,5 @@ depends: [
   "jbuilder" {build}
   "cmdliner"
   "lwt" {< "3.0.0"}
-  "xen-api-client" {>= "0.9.14"}
+  "xen-api-client-lwt"
 ]

--- a/packages/xs-extra/xapi-cli-protocol.master/descr
+++ b/packages/xs-extra/xapi-cli-protocol.master/descr
@@ -1,0 +1,4 @@
+The xapi toolstack daemon which implements the XenAPI
+
+This daemon exposes the XenAPI and is used by clients such as 'xe'
+and 'XenCenter' to manage clusters of Xen-enabled hosts.

--- a/packages/xs-extra/xapi-cli-protocol.master/opam
+++ b/packages/xs-extra/xapi-cli-protocol.master/opam
@@ -1,0 +1,13 @@
+opam-version: "1.2"
+maintainer: "xen-api@lists.xen.org"
+authors: [ "xen-api@lists.xen.org" ]
+homepage: "https://github.com/xapi-project/xen-api"
+bug-reports: "https://github.com/xapi-project/xen-api/issues"
+dev-repo: "https://github.com/xapi-project/xen-api.git"
+
+build: [[ "jbuilder" "build" "-p" name ]]
+
+depends: [
+  "jbuilder" {build & >= "1.0+beta11"}
+  "stdext"
+]

--- a/packages/xs-extra/xapi-cli-protocol.master/url
+++ b/packages/xs-extra/xapi-cli-protocol.master/url
@@ -1,0 +1,1 @@
+archive: "https://github.com/xapi-project/xen-api/archive/master/master.tar.gz"

--- a/packages/xs-extra/xapi-client.master/descr
+++ b/packages/xs-extra/xapi-client.master/descr
@@ -1,0 +1,4 @@
+The xapi toolstack daemon which implements the XenAPI
+
+This daemon exposes the XenAPI and is used by clients such as 'xe'
+and 'XenCenter' to manage clusters of Xen-enabled hosts.

--- a/packages/xs-extra/xapi-client.master/opam
+++ b/packages/xs-extra/xapi-client.master/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "xen-api@lists.xen.org"
+authors: [ "xen-api@lists.xen.org" ]
+homepage: "https://github.com/xapi-project/xen-api"
+bug-reports: "https://github.com/xapi-project/xen-api/issues"
+dev-repo: "https://github.com/xapi-project/xen-api.git"
+
+build: [[ "jbuilder" "build" "-p" name ]]
+
+depends: [
+  "jbuilder" {build & >= "1.0+beta11"}
+  "xapi-datamodel"
+  "xapi-types"
+]
+

--- a/packages/xs-extra/xapi-client.master/url
+++ b/packages/xs-extra/xapi-client.master/url
@@ -1,0 +1,1 @@
+archive: "https://github.com/xapi-project/xen-api/archive/master/master.tar.gz"

--- a/packages/xs-extra/xapi-consts.master/descr
+++ b/packages/xs-extra/xapi-consts.master/descr
@@ -1,0 +1,4 @@
+The xapi toolstack daemon which implements the XenAPI
+
+This daemon exposes the XenAPI and is used by clients such as 'xe'
+and 'XenCenter' to manage clusters of Xen-enabled hosts.

--- a/packages/xs-extra/xapi-consts.master/opam
+++ b/packages/xs-extra/xapi-consts.master/opam
@@ -1,0 +1,12 @@
+opam-version: "1.2"
+maintainer: "xen-api@lists.xen.org"
+authors: [ "xen-api@lists.xen.org" ]
+homepage: "https://github.com/xapi-project/xen-api"
+bug-reports: "https://github.com/xapi-project/xen-api/issues"
+dev-repo: "https://github.com/xapi-project/xen-api.git"
+
+build: [[ "jbuilder" "build" "-p" name ]]
+
+depends: [
+  "jbuilder" {build & >= "1.0+beta11"}
+]

--- a/packages/xs-extra/xapi-consts.master/url
+++ b/packages/xs-extra/xapi-consts.master/url
@@ -1,0 +1,1 @@
+archive: "https://github.com/xapi-project/xen-api/archive/master/master.tar.gz"

--- a/packages/xs-extra/xapi-database.master/descr
+++ b/packages/xs-extra/xapi-database.master/descr
@@ -1,0 +1,4 @@
+The xapi toolstack daemon which implements the XenAPI
+
+This daemon exposes the XenAPI and is used by clients such as 'xe'
+and 'XenCenter' to manage clusters of Xen-enabled hosts.

--- a/packages/xs-extra/xapi-database.master/opam
+++ b/packages/xs-extra/xapi-database.master/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+maintainer: "xen-api@lists.xen.org"
+authors: [ "xen-api@lists.xen.org" ]
+homepage: "https://github.com/xapi-project/xen-api"
+bug-reports: "https://github.com/xapi-project/xen-api/issues"
+dev-repo: "https://github.com/xapi-project/xen-api.git"
+
+build: [[ "jbuilder" "build" "-p" name ]]
+
+depends: [
+  "jbuilder" {build & >= "1.0+beta11"}
+  "rpc"
+  "ppx_sexp_conv"
+  "xapi-idl"
+  "xapi-libs-transitional"
+]

--- a/packages/xs-extra/xapi-database.master/url
+++ b/packages/xs-extra/xapi-database.master/url
@@ -1,0 +1,1 @@
+archive: "https://github.com/xapi-project/xen-api/archive/master/master.tar.gz"

--- a/packages/xs-extra/xapi-datamodel.master/descr
+++ b/packages/xs-extra/xapi-datamodel.master/descr
@@ -1,0 +1,4 @@
+The xapi toolstack daemon which implements the XenAPI
+
+This daemon exposes the XenAPI and is used by clients such as 'xe'
+and 'XenCenter' to manage clusters of Xen-enabled hosts.

--- a/packages/xs-extra/xapi-datamodel.master/opam
+++ b/packages/xs-extra/xapi-datamodel.master/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "xen-api@lists.xen.org"
+authors: [ "xen-api@lists.xen.org" ]
+homepage: "https://github.com/xapi-project/xen-api"
+bug-reports: "https://github.com/xapi-project/xen-api/issues"
+dev-repo: "https://github.com/xapi-project/xen-api.git"
+
+build: [[ "jbuilder" "build" "-p" name ]]
+
+depends: [
+  "jbuilder" {build & >= "1.0+beta11"}
+  "rpc"
+  "stdext"
+  "xapi-consts"
+  "xapi-database"
+  "xapi-libs-transitional"
+  "xenstore"
+]

--- a/packages/xs-extra/xapi-datamodel.master/url
+++ b/packages/xs-extra/xapi-datamodel.master/url
@@ -1,0 +1,1 @@
+archive: "https://github.com/xapi-project/xen-api/archive/master/master.tar.gz"

--- a/packages/xs-extra/xapi-idl.master/opam
+++ b/packages/xs-extra/xapi-idl.master/opam
@@ -5,38 +5,5 @@ bug-reports: "https://github.com/xapi-project/xcp-idl/issues"
 dev-repo: "git://github.com/xapi-project/xcp-idl"
 maintainer: "xen-api@lists.xen.org"
 tags: [ "org:xapi-project" ]
-build: [
-  [make "all"]
-]
-build-test: [
-  [make "test"]
-]
-install: [
-  [make "install"]
-]
-remove: [
-  ["ocamlfind" "remove" "xcp"]
-]
-depends: [
-  "ocamlfind" {build}
-  "ocamlbuild" {build}
-  "base-threads"
-  "base-unix"
-  "uri"
-  "re"
-  "cmdliner"
-  "cohttp" {< "0.22.0"}
-  "xmlm"
-  "rpc" {>= "1.9.51"}
-  "message-switch"
-  "xapi-stdext"
-  "xapi-rrd"
-  "xapi-inventory"
-  "xapi-backtrace"
-  "fd-send-recv"
-  "lwt" {< "3.0.0"}
-  "ounit" {>= "2.0.0"}
-  "ppx_sexp_conv"
-  "sexplib"
-]
+depends: [ "xcp" ]
 

--- a/packages/xs-extra/xapi-types.master/descr
+++ b/packages/xs-extra/xapi-types.master/descr
@@ -1,0 +1,4 @@
+The xapi toolstack daemon which implements the XenAPI
+
+This daemon exposes the XenAPI and is used by clients such as 'xe'
+and 'XenCenter' to manage clusters of Xen-enabled hosts.

--- a/packages/xs-extra/xapi-types.master/opam
+++ b/packages/xs-extra/xapi-types.master/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "xen-api@lists.xen.org"
+authors: [ "xen-api@lists.xen.org" ]
+homepage: "https://github.com/xapi-project/xen-api"
+bug-reports: "https://github.com/xapi-project/xen-api/issues"
+dev-repo: "https://github.com/xapi-project/xen-api.git"
+
+build: [[ "jbuilder" "build" "-p" name ]]
+
+depends: [
+  "jbuilder" {build & >= "1.0+beta11"}
+  "astring"
+  "rpc"
+  "uuidm"
+  "xapi-consts"
+  "xapi-datamodel"
+  "xapi-libs-transitional"
+]
+

--- a/packages/xs-extra/xapi-types.master/url
+++ b/packages/xs-extra/xapi-types.master/url
@@ -1,0 +1,1 @@
+archive: "https://github.com/xapi-project/xen-api/archive/master/master.tar.gz"

--- a/packages/xs-extra/xapi.master/opam
+++ b/packages/xs-extra/xapi.master/opam
@@ -3,56 +3,44 @@ maintainer: "xen-api@lists.xen.org"
 authors: [ "xen-api@lists.xen.org" ]
 homepage: "https://github.com/xapi-project/xen-api"
 bug-reports: "https://github.com/xapi-project/xen-api/issues"
-dev-repo: "git://github.com/xapi-project/xen-api"
-build: [
-	["./configure"]
-  [make]
-]
-install: [
-    ["oasis" "setup"]
-    ["ocaml" "setup.ml" "-install"]
-]
-build-test: [make "test"]
-remove: [
-    ["./configure"]
-    [make "uninstall"]
-    ["ocamlfind" "remove" "xapi"]
-    ["ocamlfind" "remove" "xapi-client"]
-    ["ocamlfind" "remove" "xapi-cli-protocol"]
-    ["ocamlfind" "remove" "xapi-consts"]
-    ["ocamlfind" "remove" "xapi-datamodel"]
-    ["ocamlfind" "remove" "xapi-database"]
-    ["ocamlfind" "remove" "xapi-types"]
-]
+dev-repo: "https://github.com/xapi-project/xen-api.git"
+
+build: [[ "jbuilder" "build" "-p" name ]]
+build-test: [[ "jbuilder" "runtest" "-p" name "-j" jobs ]]
+
 depends: [
-  "oasis" {build}
-  "ocamlfind" {build}
-  "xapi-test-utils"
-  "xapi-idl"
-  "xapi-libs-transitional"
-  "xen-api-client"
-	"xapi-netdev"
+  "jbuilder" {build & >= "1.0+beta11"}
   "cdrom"
   "fd-send-recv"
-  "xapi-forkexecd"
-  "vhd-format"
+  "mustache"
+  "mtime"
   "nbd"
-  "oclock"
+  "opasswd"
   "ounit"
+  "pci"
   "rpc"
+  "sha"
   "ssl"
-  "xapi-stdext"
-  "xapi-tapctl"
+  "stdext"
+  "tar-format"
+  "vhd-format"
+  "xapi-cli-protocol"
+  "xapi-client"
+  "xapi-consts"
+  "xapi-database"
+  "xapi-datamodel"
+  "xapi-forkexecd"
+  "xapi-idl"
+  "xapi-inventory"
+  "xapi-libs-transitional"
+  "xapi-netdev"
+  "xapi-rrdd-plugin"
+  "xapi-test-utils"
+  "xapi-types"
+  "xapi-xenopsd"
+  "xen-api-client"
   "xenctrl"
   "xenstore"
-  "xapi-inventory"
-  "tar-format"
-  "opasswd"
-  "xapi-rrdd-plugin"
-  "pci"
-  "sha"
-  "xapi-xenopsd"
-  "mustache"
 ]
 depexts: [
   [["centos"] ["pam-devel"]]

--- a/packages/xs-extra/xapi.master/opam
+++ b/packages/xs-extra/xapi.master/opam
@@ -12,7 +12,6 @@ depends: [
   "jbuilder" {build & >= "1.0+beta11"}
   "cdrom"
   "fd-send-recv"
-  "mustache"
   "mtime"
   "nbd"
   "opasswd"
@@ -38,7 +37,6 @@ depends: [
   "xapi-test-utils"
   "xapi-types"
   "xapi-xenopsd"
-  "xen-api-client"
   "xenctrl"
   "xenstore"
 ]

--- a/packages/xs-extra/xcp.master/descr
+++ b/packages/xs-extra/xcp.master/descr
@@ -1,0 +1,9 @@
+Interface descriptions and common boilerplate for xapi services.
+
+The xapi toolstack is a set of communicating services including
+  - xenopsd: low-level Xen domain management
+  - networkd: host network configuration
+  - squeezed: balances memory between domains
+  - rrdd: manages datasources and records history
+plus storage 'plugins'
+

--- a/packages/xs-extra/xcp.master/opam
+++ b/packages/xs-extra/xcp.master/opam
@@ -1,0 +1,35 @@
+opam-version: "1.2"
+authors: "Dave Scott"
+homepage: "https://github.com/xapi-project/xcp-idl"
+bug-reports: "https://github.com/xapi-project/xcp-idl/issues"
+dev-repo: "git://github.com/xapi-project/xcp-idl"
+maintainer: "xen-api@lists.xen.org"
+tags: [ "org:xapi-project" ]
+build: [[ "jbuilder" "build" "-p" name "-j" jobs ]]
+build-test: ["jbuilder" "runtest" "-p" name]
+depends: [
+  "base-threads"
+  "base-unix"
+  "cmdliner"
+  "cohttp" {< "0.22.0"}
+  "fd-send-recv"
+  "jbuilder" {build & >= "1.0+beta11"}
+  "lwt" {< "3.0.0" & >= "2.7.1"}
+  "message-switch"
+  "ocamlfind" {build}
+  "ounit" {>= "2.0.0"}
+  "ppx_sexp_conv"
+  "re"
+  "rpc" {>= "1.9.51"}
+  "sexplib"
+  "uri"
+  "xapi-backtrace"
+  "xapi-inventory"
+  "xapi-rrd"
+  "xapi-stdext-date"
+  "xapi-stdext-monadic"
+  "xapi-stdext-pervasives"
+  "xapi-stdext-threads"
+  "xmlm"
+]
+

--- a/packages/xs-extra/xcp.master/url
+++ b/packages/xs-extra/xcp.master/url
@@ -1,0 +1,1 @@
+archive: "https://github.com/xapi-project/xcp-idl/archive/master.tar.gz"

--- a/packages/xs-extra/xe.master/descr
+++ b/packages/xs-extra/xe.master/descr
@@ -1,0 +1,4 @@
+The xapi toolstack daemon which implements the XenAPI
+
+This daemon exposes the XenAPI and is used by clients such as 'xe'
+and 'XenCenter' to manage clusters of Xen-enabled hosts.

--- a/packages/xs-extra/xe.master/opam
+++ b/packages/xs-extra/xe.master/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "xen-api@lists.xen.org"
+authors: [ "xen-api@lists.xen.org" ]
+homepage: "https://github.com/xapi-project/xen-api"
+bug-reports: "https://github.com/xapi-project/xen-api/issues"
+dev-repo: "https://github.com/xapi-project/xen-api.git"
+
+build: [[ "jbuilder" "build" "-p" name ]]
+
+depends: [
+  "jbuilder" {build & >= "1.0+beta11"}
+  "stdext"
+  "xapi-cli-protocol"
+  "xapi-libs-transitional"
+]

--- a/packages/xs-extra/xe.master/url
+++ b/packages/xs-extra/xe.master/url
@@ -1,0 +1,1 @@
+archive: "https://github.com/xapi-project/xen-api/archive/master/master.tar.gz"


### PR DESCRIPTION
Depends on https://github.com/xapi-project/xen-api/pull/3274 and https://github.com/xapi-project/vncproxy/pull/12

Also updates:
- vncproxy, to use the new xen-api-client
- xcp-idl, recently ported to jbuilder

Signed-off-by: Marcello Seri <marcello.seri@citrix.com>