### PR TITLE
xen-api-sdk: depend on xapi-datamodel instead of xapi

### DIFF
--- a/packages/xs-extra/xen-api-sdk.master/opam
+++ b/packages/xs-extra/xen-api-sdk.master/opam
@@ -10,6 +10,6 @@ tags: [ "org:xapi-project" ]
 build: [[ "jbuilder" "build" "-p" name ]]
 depends: [
   "jbuilder" {build}
-  "xapi"
+  "xapi-datamodel"
   "mustache"
 ]


### PR DESCRIPTION
Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>