### PR TITLE
Avoid illegal instructions from nocrypto

### DIFF
--- a/packages/upstream/nocrypto.0.5.3/opam
+++ b/packages/upstream/nocrypto.0.5.3/opam
@@ -9,6 +9,7 @@ license:      "BSD2"
 build: [
   [ "./configure" "--prefix" prefix
      "--%{lwt:enable}%-lwt"
+     "--disable-modernity"
      "--%{mirage-xen+mirage-entropy-xen:enable}%-xen" ]
   [ make ]
 ]
@@ -39,7 +40,7 @@ conflicts: [
 ]
 
 build-test: [
-  [ "./configure" "--%{ounit:enable}%-tests" ]
+  [ "./configure" "--%{ounit:enable}%-tests" "--disable-modernity" ]
   [ make "test" ]
 ]
 


### PR DESCRIPTION
Nocrypto detects CPU features at *build time*, instead of runtime.
If the build machine is newer than the machine you install the binary on then it
would crash with an illegal instruction on startup.
See https://github.com/mirleft/ocaml-nocrypto#illegal-instructions and https://github.com/mirleft/ocaml-nocrypto/issues/73

Since there is no runtime detection the only safe thing to do is to disable the
use of these instructions always.
For version 0.5.3 this is done with `--disable-modernity`, for 0.5.4 it'll be
`NOCRYPTO_ACCELERATE=false` environment variable.

Tested with `opam reinstall -y nocrypto.0.5.3 -v`: without this patch I see `-maes` in the build output, with this patch I do not. (note: you only see `-maes` if `/proc/cpuinfo` has the `aes` flag)