### PR TITLE
x509: update to add upper bound on asn1-combinators

### DIFF
--- a/packages/upstream/x509.0.5.3/opam
+++ b/packages/upstream/x509.0.5.3/opam
@@ -22,7 +22,7 @@ depends: [
   "ppx_sexp_conv" {build}
   "cstruct" {>= "1.6.0"}
   "sexplib"
-  "asn1-combinators" {>= "0.1.1"}
+  "asn1-combinators" {>= "0.1.1" & < "0.2.0"}
   "nocrypto" {>= "0.5.3"}
   "base-bytes"
   "ounit" {test}


### PR DESCRIPTION
Compilation fails with version 0.2.0 of asn1-combinators. The upper bound has already been added to the opam file of x509 in the main OPAM repository, so I've just copied that one.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>