### PR TITLE
netlink: update depexts for Debian 9 Stretch

### DIFF
--- a/packages/xs/netlink.0.3.1/opam
+++ b/packages/xs/netlink.0.3.1/opam
@@ -9,7 +9,7 @@ depends: [
   "ctypes-foreign"
 ]
 depexts: [
- [ ["debian"] ["libnl-3" ] ]
+ [ ["debian"] ["libnl-3-200" "libnl-route-3-200"] ]
  [ ["ubuntu"] ["libnl-3-200" "libnl-route-3-200"] ]
  [ ["centos"] ["libnl3"] ]
 ]


### PR DESCRIPTION
Different packages are required on the new Debian stable.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>