### PR TITLE
Add dev-repos.sh - find URLs of all repos from opam files

### DIFF
--- a/tools/dev-repos.sh
+++ b/tools/dev-repos.sh
@@ -1,0 +1,9 @@
+#! /bin/sh
+# This emits the URLs of all dev repos mentioned in the opam 
+# files. This relies on the opam-ed tool that can be installed using
+# opam.
+
+find . -name opam -type f | while read opam; do
+  cat $opam | opam-ed 'get dev-repo' 
+done | sort -u | tr -d '"'
+


### PR DESCRIPTION
This is a small tool to extract information from all opam files. It finds the URLs of all dev-repos but it would be easy to extract other information.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>