### PR TITLE
camlp4: disable preinstalled check

### DIFF
--- a/packages/upstream/camlp4.4.04+1/opam
+++ b/packages/upstream/camlp4.4.04+1/opam
@@ -25,6 +25,6 @@ remove: [
 ]
 
 patches: [ "termux.patch" "f0ea53725465260556832398096cef8d3f20b49d.patch" ]
-available: [ (!preinstalled) & (ocaml-version >= "4.04") & (ocaml-version < "4.05") ]
+available: [ (ocaml-version >= "4.04") & (ocaml-version < "4.05") ]
 bug-reports: "https://github.com/ocaml/camlp4/issues"
 dev-repo: "https://github.com/ocaml/camlp4.git"


### PR DESCRIPTION
camlp4 is also preinstalled for us, but we want both in 

Signed-off-by: Marcello Seri <marcello.seri@citrix.com>