### PR TITLE
nocrypto: backport fix for parallel builds from opam-repository

### DIFF
--- a/packages/upstream/nocrypto.0.5.4/opam
+++ b/packages/upstream/nocrypto.0.5.4/opam
@@ -10,6 +10,7 @@ tags:          [ "org:mirage" ]
 available:     [ ocaml-version >= "4.02.0" ]
 
 build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false"
+                "--jobs" "1"
                 "--with-lwt" "%{lwt:installed}%"
                 "--xen" "%{mirage-xen:installed}%"
                 "--freestanding" "%{mirage-solo5:installed}%"

--- a/packages/upstream/result.1.3/opam
+++ b/packages/upstream/result.1.3/opam
@@ -6,4 +6,4 @@ dev-repo: "https://github.com/janestreet/result.git"
 bug-reports: "https://github.com/janestreet/result/issues"
 license: "BSD3"
 build: [["jbuilder" "build" "-p" name "-j" jobs]]
-depends: ["jbuilder" {>= "1.0+beta11"}]
+depends: ["jbuilder" {build & >= "1.0+beta11"}]


### PR DESCRIPTION
See https://github.com/mirleft/ocaml-nocrypto/issues/136 and the corresponding PR in `opam-repository` https://github.com/ocaml/opam-repository/pull/11032

Also backport a minor dependency fix for `result`.

Signed-off-by: Marcello Seri <marcello.seri@citrix.com>