### PR TITLE
Add lwt_log package

### DIFF
--- a/packages/upstream/lwt_log.1.0.0/descr
+++ b/packages/upstream/lwt_log.1.0.0/descr
@@ -1,0 +1,1 @@
+Lwt logging library (deprecated)

--- a/packages/upstream/lwt_log.1.0.0/opam
+++ b/packages/upstream/lwt_log.1.0.0/opam
@@ -1,0 +1,25 @@
+opam-version: "1.2"
+version: "1.0.0"
+maintainer: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+]
+authors: [
+  "Shawn Wagner"
+  "Jérémie Dimino"
+]
+homepage: "https://github.com/ocsigen/lwt"
+doc: "https://ocsigen.org/lwt/api/Lwt_log"
+dev-repo: "https://github.com/ocsigen/lwt.git"
+bug-reports: "https://github.com/ocsigen/lwt/issues"
+license: "LGPL"
+
+depends: [
+  "jbuilder" {build}
+  # This will be constrained with an upper bound once the log library is fully
+  # factored out of package lwt.
+  "lwt"
+]
+
+build: [
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]

--- a/packages/upstream/lwt_log.1.0.0/url
+++ b/packages/upstream/lwt_log.1.0.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/ocsigen/lwt/archive/3.2.0.tar.gz"
+checksum: "cf4256845e18c4d0f39afa7b32b3d6fe"

--- a/packages/xs-extra/message-switch.master/opam
+++ b/packages/xs-extra/message-switch.master/opam
@@ -16,6 +16,8 @@ build-test: [
 depends: [
   "jbuilder" {build}
   "ocamlfind" {build}
+  "lwt"
+  "lwt_log"
   "message-switch-lwt"
   "message-switch-unix"
   "cmdliner"

--- a/packages/xs-extra/wsproxy.master/opam
+++ b/packages/xs-extra/wsproxy.master/opam
@@ -12,6 +12,7 @@ depends: [
   "jbuilder" {build}
   "base64"
   "lwt" {>= "3.0.0"}
+  "lwt_log"
   "re"
   "ounit" {test}
   "qcheck" {test}

--- a/packages/xs-extra/xapi-nbd.master/opam
+++ b/packages/xs-extra/xapi-nbd.master/opam
@@ -11,6 +11,7 @@ depends: [
   "alcotest" {test}
   "cmdliner"
   "lwt" {>= "3.0.0"}
+  "lwt_log"
   "mirage-block-unix"
   "nbd-lwt-unix"
   "uri"

--- a/packages/xs/nbd.4.0.0+beta1/opam
+++ b/packages/xs/nbd.4.0.0+beta1/opam
@@ -18,6 +18,7 @@ depends: [
   "mirage-block-lwt"
   "mirage-types-lwt" {>= "3.0.0"}
   "lwt" {>= "2.7.0"}
+  "lwt_log"
   "result"
   "rresult"
   "sexplib"


### PR DESCRIPTION
Prepare for the separation of the deprecated Lwt_log library: in the
future it will be split it into a completely separate lwt_log package,
which is currently a "proxy" package to make the transition smooth.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>