### PR TITLE
ocb-stubblr: bytecode/custom targets need cclib as well

### DIFF
--- a/packages/upstream/ocb-stubblr.0.1.1/files/0001-bytecode-custom-needs-cclib-as-well.patch
+++ b/packages/upstream/ocb-stubblr.0.1.1/files/0001-bytecode-custom-needs-cclib-as-well.patch
@@ -1,0 +1,28 @@
+From cf29928482b82a6ccd3673a3491f90c243f5668e Mon Sep 17 00:00:00 2001
+From: Marcello Seri <marcello.seri@citrix.com>
+Date: Wed, 7 Mar 2018 16:25:42 +0000
+Subject: [PATCH] bytecode / custom needs -cclib as well
+
+See https://github.com/pqwy/ocb-stubblr/pull/11 and comments therein
+
+Signed-off-by: Marcello Seri <marcello.seri@citrix.com>
+---
+ src/ocb_stubblr.ml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/ocb_stubblr.ml b/src/ocb_stubblr.ml
+index b68c37a..a0ee035 100644
+--- a/src/ocb_stubblr.ml
++++ b/src/ocb_stubblr.ml
+@@ -160,7 +160,7 @@ let link_flag () =
+     S [A switch; A ("-l"^name)]
+   and dep flag = Pathname.([remove_extension flag -.- "a"]) in
+   pflag ["link"; "ocaml"; "library"; "byte"] tag (libarg "-dllib");
+-  pflag ["link"; "ocaml"; "library"; "native"] tag  (libarg "-cclib");
++  pflag ["link"; "ocaml"; "library"] tag  (libarg "-cclib");
+   pdep ["link"; "ocaml"] tag dep;
+   pdep ["compile"; "ocaml"] tag dep
+   (* XXX sneak in '-I' for compile;ocaml;program ?? *)
+-- 
+2.14.1
+

--- a/packages/upstream/ocb-stubblr.0.1.1/opam
+++ b/packages/upstream/ocb-stubblr.0.1.1/opam
@@ -15,3 +15,7 @@ depends: [
   "astring" ]
 depopts: []
 build: [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false" ]
+patches: [
+    "0001-bytecode-custom-needs-cclib-as-well.patch"
+]
+


### PR DESCRIPTION
See https://github.com/pqwy/ocb-stubblr/pull/11

This enables us to do `jbuilder utop ocaml/xapi` and be able to
triage issues using the internal xapi library.

Signed-off-by: Marcello Seri <marcello.seri@citrix.com>