### PR TITLE
shared_block_ring: add missing opam dependency

### DIFF
--- a/packages/upstream/shared-block-ring.2.4.0+1/opam
+++ b/packages/upstream/shared-block-ring.2.4.0+1/opam
@@ -21,6 +21,7 @@ depends: [
   "ppx_deriving" {build}
   "ppx_sexp_conv" {build}
   "lwt" {>= "3.2.0"}
+  "lwt_log"
   "ocamlfind"
   "ounit"
   "mirage-types-lwt" {>= "3.0.0"}


### PR DESCRIPTION
This should fix some of the travis issues


Signed-off-by: Marcello Seri <marcello.seri@citrix.com>