### PR TITLE
xs-opam: auto update

### DIFF
--- a/packages/upstream/ppx_cstruct.3.2.1/opam
+++ b/packages/upstream/ppx_cstruct.3.2.1/opam
@@ -21,7 +21,6 @@ depends: [
   "ounit" {test}
   "ppx_tools_versioned" {>="5.0.1"}
   "ocaml-migrate-parsetree"
-  "ppx_driver"    {test & >= "v0.9.0"}
   "ppx_sexp_conv" {test}
   "cstruct-unix"  {test}
 ]


### PR DESCRIPTION
Upgrades:

	- ppxlib: 0.2.0->0.3.0
	- ppx_typerep_conv: v0.11.0->v0.11.1
	- ppx_sexp_conv: v0.11.1->v0.11.2
	- ppx_enumerate: v0.11.0->v0.11.1
	- ppx_compare: v0.11.0->v0.11.1
	- ppx_hash: v0.11.0->v0.11.1
	- ppx_variants_conv: v0.11.0->v0.11.1
	- ppx_bin_prot: v0.11.0->v0.11.1

ppx_cstruct: remove unnecessary test dependency (should fix xcp-idl travis tests)