### PR TITLE
upstream-extra: add merlin and ocp-indent for convenience

### DIFF
--- a/packages/upstream-extra/merlin.3.0.5/descr
+++ b/packages/upstream-extra/merlin.3.0.5/descr
@@ -1,0 +1,3 @@
+Editor helper, provides completion, typing and source browsing in Vim and Emacs
+
+Merlin is an assistant for editing OCaml code. It aims to provide the features available in modern IDEs: error reporting, auto completion, source browsing and much more.

--- a/packages/upstream-extra/merlin.3.0.5/opam
+++ b/packages/upstream-extra/merlin.3.0.5/opam
@@ -1,0 +1,57 @@
+opam-version: "1.2"
+maintainer: "defree@gmail.com"
+authors: "The Merlin team"
+homepage: "https://github.com/ocaml/merlin"
+bug-reports: "https://github.com/ocaml/merlin/issues"
+dev-repo: "https://github.com/ocaml/merlin.git"
+build: [
+  ["./configure" "--prefix" prefix]
+  ["rm" "-rf" "%{prefix}%/share/ocamlmerlin"]
+  [make "-j" jobs]
+]
+depends: [
+  "ocamlfind" {>= "1.5.2"}
+  "yojson"
+]
+available: [ocaml-version >= "4.02.1" & ocaml-version < "4.07"]
+post-messages: [
+  "
+merlin installed.
+
+Quick setup for VIM
+-------------------
+Append this to your .vimrc to add merlin to vim's runtime-path:
+  let g:opamshare = substitute(system('opam config var share'),'\\n$','','''')
+  execute \"set rtp+=\" . g:opamshare . \"/merlin/vim\"
+
+Also run the following line in vim to index the documentation:
+  :execute \"helptags \" . g:opamshare . \"/merlin/vim/doc\"
+
+Quick setup for EMACS
+-------------------
+Add opam emacs directory to your load-path by appending this to your .emacs:
+  (let ((opam-share (ignore-errors (car (process-lines \"opam\" \"config\" \"var\" \"share\")))))
+   (when (and opam-share (file-directory-p opam-share))
+    ;; Register Merlin
+    (add-to-list 'load-path (expand-file-name \"emacs/site-lisp\" opam-share))
+    (autoload 'merlin-mode \"merlin\" nil t nil)
+    ;; Automatically start it in OCaml buffers
+    (add-hook 'tuareg-mode-hook 'merlin-mode t)
+    (add-hook 'caml-mode-hook 'merlin-mode t)
+    ;; Use opam switch to lookup ocamlmerlin binary
+    (setq merlin-command 'opam)))
+
+Take a look at https://github.com/ocaml/merlin for more information
+
+Quick setup with opam-user-setup
+--------------------------------
+
+Opam-user-setup support Merlin.
+
+  $ opam user-setup install
+
+should take care of basic setup.
+See https://github.com/OCamlPro/opam-user-setup
+  "
+    {success & !user-setup:installed}
+]

--- a/packages/upstream-extra/merlin.3.0.5/url
+++ b/packages/upstream-extra/merlin.3.0.5/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ocaml/merlin/archive/v3.0.5.tar.gz"
+checksum: "279818ec1d1c984b3ece0f59381f4757"

--- a/packages/upstream-extra/ocp-build.1.99.20-beta/descr
+++ b/packages/upstream-extra/ocp-build.1.99.20-beta/descr
@@ -1,0 +1,6 @@
+Project builder for OCaml
+
+ocp-build main features are:
+* simple library/program description
+* detection of ocamlfind libraries (parsing of META)
+* incremental and parallel compilation of OCaml projects

--- a/packages/upstream-extra/ocp-build.1.99.20-beta/opam
+++ b/packages/upstream-extra/ocp-build.1.99.20-beta/opam
@@ -1,0 +1,55 @@
+(**************************************************************)
+(*                                                            *)
+(*      This file is managed by ocp-autoconf                  *)
+(*  Remove it from `manage_files` in 'ocp-autoconf.config'    *)
+(*  if you want to modify it manually (or use 'opam.trailer') *)
+(*                                                            *)
+(**************************************************************)
+
+opam-version: "1.2"
+maintainer: "Fabrice Le Fessant <fabrice.le_fessant@ocamlpro.com>"
+authors: [
+  "Fabrice Le Fessant <fabrice.le_fessant@ocamlpro.com>"
+]
+homepage: "http://www.typerex.org/ocp-build.html"
+dev-repo: "https://github.com/OCamlPro/ocp-build.git"
+bug-reports: "https://github.com/OCamlPro/ocp-build/issues"
+build: [
+  [     "./configure"
+    "--prefix"
+    "%{prefix}%"
+  ]
+  [ make ]
+]
+install: [
+  [ make "install" ]
+]
+remove: [
+  [ "rm" "-f" "%{prefix}%/bin/ocp-build"   ]
+  [ "rm" "-f" "%{prefix}%/bin/ocp-pp"   ]
+  [ "rm" "-rf" "%{prefix}%/lib/ocaml/typerex/ocp-build"   ]
+  [ "rm" "-rf" "%{prefix}%/lib/ocaml/typerex/ocplib-compat"   ]
+  [ "rm" "-rf" "%{prefix}%/lib/ocaml/typerex/ocplib-debug"   ]
+  [ "rm" "-rf" "%{prefix}%/lib/ocaml/typerex/ocplib-lang"   ]
+  [ "rm" "-rf" "%{prefix}%/lib/ocaml/typerex/ocplib-subcmd"   ]
+  [ "rm" "-rf" "%{prefix}%/lib/ocaml/typerex/ocplib-system"   ]
+  [ "rm" "-rf" "%{prefix}%/lib/ocaml/typerex/ocplib-unix"   ]
+  [ "rm" "-rf" "%{prefix}%/lib/ocaml/typerex/installed.ocp"   ]
+  [ "rm" "-rf" "%{prefix}%/lib/ocaml/site-ocp2/ocp-build"   ]
+  [ "sh" "-exc" "rmdir %{prefix}%/lib/ocaml/typerex || true"   ]
+]
+available: [ocaml-version >= "4.02.1"]
+
+(**************************************************************)
+(*                                                            *)
+(* From opam.trailer:                                         *)
+(*                                                            *)
+(**************************************************************)
+
+conflicts: [ "typerex"  {< "1.99.7"} "typerex-build" ]
+depends: [
+    "ocamlfind" (* not strictly needed by ocp-build, but
+                  since opam installs packages in a non-standard
+                  repository, we need it... *)
+    "cmdliner" { >= "1.0" }
+]

--- a/packages/upstream-extra/ocp-build.1.99.20-beta/url
+++ b/packages/upstream-extra/ocp-build.1.99.20-beta/url
@@ -1,0 +1,2 @@
+archive: "http://github.com/OCamlPro/ocp-build/archive/1.99.20-beta.tar.gz"
+checksum: "72d9c1b1a42d1873628e2d6e7529d8cb"

--- a/packages/upstream-extra/ocp-indent.1.6.1/descr
+++ b/packages/upstream-extra/ocp-indent.1.6.1/descr
@@ -1,0 +1,13 @@
+A simple tool to indent OCaml programs
+
+Ocp-indent is based on an approximate, tolerant OCaml parser and a simple stack
+machine ; this is much faster and more reliable than using regexps. Presets and
+configuration options available, with the possibility to set them project-wide.
+Supports most common syntax extensions, and extensible for others.
+
+Includes:
+
+* An indentor program, callable from the command-line or from within editors
+* Bindings for popular editors
+* A library that can be directly used by editor writers, or just for
+approximate parsing.

--- a/packages/upstream-extra/ocp-indent.1.6.1/opam
+++ b/packages/upstream-extra/ocp-indent.1.6.1/opam
@@ -1,0 +1,34 @@
+opam-version: "1.2"
+maintainer: "contact@ocamlpro.com"
+authors: [
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Jun Furuse"
+]
+homepage: "http://www.typerex.org/ocp-indent.html"
+bug-reports: "https://github.com/OCamlPro/ocp-indent/issues"
+license: "LGPL"
+tags: ["org:ocamlpro" "org:typerex"]
+dev-repo: "https://github.com/OCamlPro/ocp-indent.git"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocp-build" {build & >= "1.99.6-beta"}
+  "cmdliner" {>= "1.0.0"}
+  "base-bytes"
+]
+post-messages: [
+  "
+This package requires additional configuration for use in editors. Install package 'user-setup', or manually:
+
+* for Emacs, add these lines to ~/.emacs:
+  (add-to-list 'load-path \"%{share}%/emacs/site-lisp\")
+  (require 'ocp-indent)
+
+* for Vim, add this line to ~/.vimrc:
+  set rtp^=\"%{share}%/ocp-indent/vim\"
+  "
+    {success & !user-setup:installed}
+]

--- a/packages/upstream-extra/ocp-indent.1.6.1/url
+++ b/packages/upstream-extra/ocp-indent.1.6.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/OCamlPro/ocp-indent/archive/1.6.1.tar.gz"
+checksum: "935d03f4f6376d687c46f350ff5eecdd"


### PR DESCRIPTION
These will not be installed by default, but will be installable with `opam` by developers

Signed-off-by: Marcello Seri <marcello.seri@citrix.com>