### PR TITLE
Add missing package diet: required by Travis on xcp-idl due to mirage-block-unix

### DIFF
--- a/packages/upstream-extra/diet/diet.0.1/descr
+++ b/packages/upstream-extra/diet/diet.0.1/descr
@@ -1,0 +1,6 @@
+Discrete Interval Encoding Trees
+
+This is based on the
+[Functional Pearls: Diets for Fat Sets](https://web.engr.oregonstate.edu/~erwig/papers/Diet_JFP98.pdf)
+by Martin Erwig.
+

--- a/packages/upstream-extra/diet/diet.0.1/opam
+++ b/packages/upstream-extra/diet/diet.0.1/opam
@@ -1,0 +1,29 @@
+opam-version: "1.2"
+maintainer: "dave@recoil.org"
+authors: ["David Scott"]
+license: "ISC"
+homepage: "https://github.com/djs55/ocaml-diet"
+dev-repo: "https://github.com/djs55/ocaml-diet.git"
+bug-reports: "https://github.com/djs55/ocaml-diet/issues"
+doc: "https://djs55.github.io/ocaml-diet"
+
+build: [
+  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "result"
+  "sexplib"
+  "jbuilder" {build & >="1.0+beta10"}
+  "ppx_tools" {build}
+  "ppx_sexp_conv" {build}
+  "ppx_type_conv" {build}
+  "ounit" {test}
+]
+
+build-test: [
+  [ make "test" ]
+]
+
+available: [ocaml-version >= "4.03.0"]

--- a/packages/upstream-extra/diet/diet.0.1/url
+++ b/packages/upstream-extra/diet/diet.0.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/djs55/ocaml-diet/archive/v0.1.tar.gz"
+checksum: "f31bb2fc82a04a9914cc4d5017978014"


### PR DESCRIPTION
See build failure on https://github.com/xapi-project/xcp-idl/pull/231
