### PR TITLE
vhd-format: add required integers dependency from patch

### DIFF
--- a/packages/upstream/vhd-format.0.9.2+4/opam
+++ b/packages/upstream/vhd-format.0.9.2+4/opam
@@ -12,6 +12,7 @@ build: [[ "jbuilder" "build" "-p" name "-j" jobs ]]
 depends: [
   "jbuilder" {build}
   "cstruct" {>= "1.9"}
+  "integers"
   "io-page"
   "rresult"
   "uuidm"


### PR DESCRIPTION
This dependency is added by one of the patches to the opam file, but
that does not work - we have to change the opam file itself.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>