### PR TITLE
add depext to upstream-extra

### DIFF
--- a/packages/upstream-extra/opam-depext.1.1.2/descr
+++ b/packages/upstream-extra/opam-depext.1.1.2/descr
@@ -1,0 +1,6 @@
+Query and install external dependencies of OPAM packages
+
+opam-depext is a simple program intended to facilitate the interaction between
+OPAM packages and the host package management system. It can query OPAM for the
+right external dependencies on a set of packages, depending on the host OS, and
+call the OS's package manager in the appropriate way to install them.

--- a/packages/upstream-extra/opam-depext.1.1.2/opam
+++ b/packages/upstream-extra/opam-depext.1.1.2/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+maintainer: [
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+]
+authors: [
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+]
+homepage: "https://github.com/ocaml/opam-depext"
+bug-reports: "https://github.com/ocaml/opam-depext/issues"
+license: "LGPL-2.1 with OCaml linking exception"
+tags: "flags:plugin"
+dev-repo: "https://github.com/ocaml/opam-depext.git#2.0"
+build: [make]
+available: [opam-version >= "2.0.0~beta5"]

--- a/packages/upstream-extra/opam-depext.1.1.2/url
+++ b/packages/upstream-extra/opam-depext.1.1.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ocaml/opam-depext/archive/v1.1.2.tar.gz"
+checksum: "411ccffad38a77cf413172a8a35ef9b9"


### PR DESCRIPTION
upstream has switched to OPAM 2 containers by default, but was missing the depext plugin.
This is fine when using the upstream opam repository because it just be
installed, but when we use base remote set to xs-opam this will fail
because it can't find it.
Meantime this got fixed upstream, but nevertheless it would be useful to
have this package in xs-opam because we use it.
