### PR TITLE
Sync xcp-rrd opam file: use rpclib optionally if available

### DIFF
--- a/packages/xs/rrd.1.3.0/opam
+++ b/packages/xs/rrd.1.3.0/opam
@@ -13,7 +13,8 @@ depends: [
   "jbuilder" {build & >= "1.0+beta10"}
   "base-bigarray"
   "base-unix"
-  "rpc" {>= "1.9.51"}
+  ( "rpc" {>= "1.9.51" & < "5.0.0"}
+  | ("rpclib" & "ppx_deriving_rpc") )
   "xmlm"
   "uuidm"
   "ounit" {test}


### PR DESCRIPTION
Sync from https://github.com/xapi-project/xcp-rrd/pull/26
