### PR TITLE
xapi.opam: add dependency on ctypes for ocaml-pci

### DIFF
--- a/packages/xs-extra/xapi.master/opam
+++ b/packages/xs-extra/xapi.master/opam
@@ -12,6 +12,8 @@ depends: [
   "jbuilder" {build & >= "1.0+beta11"}
   "alcotest"
   "cdrom"
+  "ctypes" {>= "0.4"}
+  "ctypes-foreign" {>= "0.4"}
   "fd-send-recv"
   "message-switch-unix"
   "mtime"


### PR DESCRIPTION
The dependencies are required because xapi vendors ocaml-pci, which
requires them.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>