### PR TITLE
Fix Travis: install opam-depext

### DIFF
--- a/packages/upstream-extra/depext.1.0.5/descr
+++ b/packages/upstream-extra/depext.1.0.5/descr
@@ -1,0 +1,7 @@
+Query and install external dependencies of OPAM packages
+
+opam-depext is a simple program intended to facilitate the interaction between
+OPAM packages and the host package management system. It can perform OS and
+distribution detection, query OPAM for the right external dependencies on a set
+of packages, and call the OS's package manager in the appropriate way to install
+them.

--- a/packages/upstream-extra/depext.1.0.5/opam
+++ b/packages/upstream-extra/depext.1.0.5/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+maintainer: [
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+]
+authors: [
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+]
+homepage: "https://github.com/ocaml/opam-depext"
+bug-reports: "https://github.com/ocaml/opam-depext/issues"
+license: "LGPL-3.0 with OCaml linking exception"
+tags: "flags:plugin"
+dev-repo: "https://github.com/ocaml/opam-depext.git"
+build: [make]
+available: [opam-version >= "1.1.0" & opam-version < "2.0.0~beta5"]

--- a/packages/upstream-extra/depext.1.0.5/url
+++ b/packages/upstream-extra/depext.1.0.5/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ocaml/opam-depext/releases/download/v1.0.5/opam-depext-full-1.0.5.tbz"
+checksum: "85bcce28ed7efa75cf54bbff531eea14"

--- a/packages/upstream-extra/depext.transition/opam
+++ b/packages/upstream-extra/depext.transition/opam
@@ -1,0 +1,10 @@
+opam-version: "2.0"
+maintainer: [
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+]
+depends: ["ocaml" "opam-depext"]
+available: [opam-version >= "2.0.0~beta5"]
+synopsis: "opam-depext transition package"
+description:
+  "This package has been renamed to 'opam-depext' and can safely be removed"


### PR DESCRIPTION
After removing depext, we now need to install opam-depext.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>