### PR TITLE
Add xapi-clusterd-test.opam

### DIFF
--- a/packages/xs-extra-dummy/xapi-clusterd-test.master/opam
+++ b/packages/xs-extra-dummy/xapi-clusterd-test.master/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+
+depends: [
+  "jbuilder" {build}
+  "angstrom"
+  "astring"
+  "base64"
+  "cohttp"
+  "cohttp-lwt"
+  "cohttp-lwt-unix"
+  "dlm"
+  "fmt"
+  "inotify"
+  "ipaddr"
+  "message-switch-lwt"
+  "mtime" { >= "1.1.0" }
+  "rpc" { >= "1.9.53" }
+  "uuidm"
+  "xapi-idl"
+  "xen-api-client"
+  "xen-api-client-lwt"
+]


### PR DESCRIPTION
So now we can install all the dependencies using opam to build
xapi-clusterd.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>