### PR TITLE
make depext work again, various improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ NAME 	= xs-opam-repo-$(VERSION)
 .PHONY: all archive clean
 
 all:
-	./tools/travis.sh
+	docker build -f tools/Dockerfile -t xenserver/xs-opam:$(VERSION) .
 
 archive: $(NAME).tar.gz
 

--- a/Makefile
+++ b/Makefile
@@ -12,11 +12,14 @@ all:
 archive: $(NAME).tar.gz
 
 $(NAME).tar.gz:
+	# don't package ocaml, do package cache
+	rm -rf packages/ocaml .
 	opam admin cache
 	git archive --format=tar.gz --prefix=$(NAME)/ HEAD > $@
 	tar zxf $@
 	cd $(NAME) && ln -fs ../cache .
 	tar czhf $@ $(NAME)
+	mv ocaml packages
 
 clean:
 	rm -f  $(NAME).tar.gz

--- a/packages/ocaml/base-bigarray.base/descr
+++ b/packages/ocaml/base-bigarray.base/descr
@@ -1,1 +1,0 @@
-Bigarray library distributed with the OCaml compiler

--- a/packages/ocaml/base-bigarray.base/opam
+++ b/packages/ocaml/base-bigarray.base/opam
@@ -1,5 +1,6 @@
-opam-version: "1"
-name: "base-bigarray"
-version: "base"
-synopsis: "Bigarray library distributed with the OCaml compiler"
+opam-version: "2.0"
 maintainer: "https://github.com/ocaml/opam-repository/issues"
+description: """
+Bigarray library distributed with the OCaml compiler
+"""
+

--- a/packages/ocaml/base-bytes.base/descr
+++ b/packages/ocaml/base-bytes.base/descr
@@ -1,1 +1,0 @@
-Bytes library distributed with the OCaml compiler

--- a/packages/ocaml/base-bytes.base/opam
+++ b/packages/ocaml/base-bytes.base/opam
@@ -1,8 +1,9 @@
 opam-version: "2.0"
-name: "base-bytes"
-version: "base"
-synopsis: "Bytes library distributed with the OCaml compiler"
 maintainer: " "
 authors: " "
 homepage: " "
-depends: [   "ocaml" {>= "4.02.0"}   "ocamlfind" {>= "1.5.3"} ]
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "ocamlfind" {>= "1.5.3"}
+]
+synopsis: "Bytes library distributed with the OCaml compiler"

--- a/packages/ocaml/base-threads.base/descr
+++ b/packages/ocaml/base-threads.base/descr
@@ -1,1 +1,0 @@
-Threads library distributed with the OCaml compiler

--- a/packages/ocaml/base-threads.base/opam
+++ b/packages/ocaml/base-threads.base/opam
@@ -1,5 +1,6 @@
-opam-version: "1"
-name: "base-threads"
-version: "base"
-synopsis: "Threads library distributed with the OCaml compiler"
+opam-version: "2.0"
 maintainer: "https://github.com/ocaml/opam-repository/issues"
+description: """
+Threads library distributed with the OCaml compiler
+"""
+

--- a/packages/ocaml/base-unix.base/descr
+++ b/packages/ocaml/base-unix.base/descr
@@ -1,1 +1,0 @@
-Unix library distributed with the OCaml compiler

--- a/packages/ocaml/base-unix.base/opam
+++ b/packages/ocaml/base-unix.base/opam
@@ -1,5 +1,6 @@
-opam-version: "1"
-name: "base-unix"
-version: "base"
-synopsis: "Unix library distributed with the OCaml compiler"
+opam-version: "2.0"
 maintainer: "https://github.com/ocaml/opam-repository/issues"
+description: """
+Unix library distributed with the OCaml compiler
+"""
+

--- a/packages/ocaml/ocaml-base-compiler.4.06.1/opam
+++ b/packages/ocaml/ocaml-base-compiler.4.06.1/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+synopsis: "Official 4.06.1 release"
+maintainer: "platform@lists.ocaml.org"
+depends: [
+  "ocaml" {= "4.06.1" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  ["./configure" "-prefix" prefix "-with-debug-runtime"]
+    {os != "openbsd" & os != "freebsd" & os != "macos"}
+  [
+    "./configure"
+    "-prefix"
+    prefix
+    "-with-debug-runtime"
+    "-cc"
+    "cc"
+    "-aspp"
+    "cc -c"
+  ] {os = "openbsd" | os = "freebsd" | os = "macos"}
+  [make "world"]
+  [make "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.06.1.tar.gz"
+  checksum: "md5=d02eb67b828de22c3f97d94b3c46acba"
+}

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -5,11 +5,12 @@ MAINTAINER  Christian Lindig <christian.lindig@citrix.com>
 RUN sudo apt-get install -qq -yy \
   debianutils hwdata libdlm-dev libffi-dev libgmp-dev libnl-3-200   \
   libnl-route-3-200 libpam-dev libpci-dev libssl-dev libsystemd-dev \
-  libxen-dev linux-libc-dev m4 perl pkg-config python uuid-dev
+  libxen-dev linux-libc-dev m4 perl pkg-config python uuid-dev \
+  && sudo apt-get clean
 
-COPY . /mnt
+COPY . /tmp/xs-opam
 
-RUN opam repo remove --all default
-RUN opam repo add xs-opam file:///mnt
-RUN opam depext -y xs-toolstack
-RUN opam install -j 4 xs-toolstack
+RUN opam repo remove --all default \
+ && opam repo add xs-opam file:///tmp/xs-opam \
+ && opam depext -y xs-toolstack \
+ && opam install -j 4 xs-toolstack

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,0 +1,15 @@
+
+FROM        ocaml/opam2:debian-9-ocaml-4.06
+MAINTAINER  Christian Lindig <christian.lindig@citrix.com>
+
+RUN sudo apt-get install -qq -yy \
+  debianutils hwdata libdlm-dev libffi-dev libgmp-dev libnl-3-200   \
+  libnl-route-3-200 libpam-dev libpci-dev libssl-dev libsystemd-dev \
+  libxen-dev linux-libc-dev m4 perl pkg-config python uuid-dev
+
+COPY . /mnt
+
+RUN opam repo remove --all default
+RUN opam repo add xs-opam file:///mnt
+RUN opam depext -y xs-toolstack
+RUN opam install -j 4 xs-toolstack

--- a/tools/travis.sh
+++ b/tools/travis.sh
@@ -19,6 +19,7 @@ sudo apt-get install -qq -yy \
 
 opam repo remove --all default
 opam repo add xs-opam file:///mnt
+opam depext -vv -y xs-toolstack
 opam install -j $(getconf _NPROCESSORS_ONLN) xs-toolstack
 EOF
 


### PR DESCRIPTION
Using this repository as a base repository so far only worked for opam install but failed for opam depext for reasons that are not entirely clear. This series of commits tried to fix it while also making sure it still works for building RPMs from an archive of this repository.

* The "all" target is more useful now: it builds a docker container which can be used for development
* packages/ocaml/base-* was in Opam 1 format - so updated to Opam 2
* added ocam-base-compiler - this is required to make depext work although this is not obvious from the dependencies
* in tools/travis.sh, use "opam depext" again
* When building a tarball, don't cache the OCaml compiler
* Accidentally already pushed with a prior commit: a patch for Core's time function

```
 Makefile                                           |  5 +++-
 packages/ocaml/base-bigarray.base/descr            |  1 -
 packages/ocaml/base-bigarray.base/opam             |  9 +++---
 packages/ocaml/base-bytes.base/descr               |  1 -
 packages/ocaml/base-bytes.base/opam                |  9 +++---
 packages/ocaml/base-threads.base/descr             |  1 -
 packages/ocaml/base-threads.base/opam              |  9 +++---
 packages/ocaml/base-unix.base/descr                |  1 -
 packages/ocaml/base-unix.base/opam                 |  9 +++---
 packages/ocaml/ocaml-base-compiler.4.06.1/opam     | 33 ++++++++++++++++++++++
 .../upstream/core.v0.11.3/files/ca-297060.patch    | 12 ++++++++
 packages/upstream/core.v0.11.3/opam                |  1 +
 tools/Dockerfile                                   | 15 ++++++++++
 tools/travis.sh                                    |  1 +
```
