### PR TITLE
Sync cohttp opam files with upstream repo

### DIFF
--- a/packages/upstream/cohttp-async.1.1.1/opam
+++ b/packages/upstream/cohttp-async.1.1.1/opam
@@ -36,6 +36,32 @@ build: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+synopsis: "An OCaml library for HTTP clients and servers"
+description: """
+[![Join the chat at https://gitter.im/mirage/ocaml-cohttp](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/mirage/ocaml-cohttp?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+
+Cohttp is an OCaml library for creating HTTP daemons. It has a portable
+HTTP parser, and implementations using various asynchronous programming
+libraries:
+
+* `Cohttp_lwt_unix` uses the [Lwt](https://ocsigen.org/lwt/) library, and
+  specifically the UNIX bindings.
+* `Cohttp_async` uses the [Async](https://realworldocaml.org/v1/en/html/concurrent-programming-with-async.html)
+  library.
+* `Cohttp_lwt` exposes an OS-independent Lwt interface, which is used
+  by the [Mirage](https://mirage.io/) interface to generate standalone
+  microkernels (use the cohttp-mirage subpackage).
+* `Cohttp_lwt_xhr` compiles to a JavaScript module that maps the Cohttp
+  calls to XMLHTTPRequests.  This is used to compile OCaml libraries like
+  the GitHub bindings to JavaScript and still run efficiently.
+
+You can implement other targets using the parser very easily. Look at the `IO`
+signature in `lib/s.mli` and implement that in the desired backend.
+
+You can activate some runtime debugging by setting `COHTTP_DEBUG` to any
+value, and all requests and responses will be written to stderr.  Further
+debugging of the connection layer can be obtained by setting `CONDUIT_DEBUG`
+to any value."""
 url {
   src: "https://github.com/mirage/ocaml-cohttp/archive/v1.1.1.tar.gz"
   checksum: [

--- a/packages/upstream/cohttp-lwt-unix.1.1.1/opam
+++ b/packages/upstream/cohttp-lwt-unix.1.1.1/opam
@@ -35,6 +35,32 @@ build: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+synopsis: "An OCaml library for HTTP clients and servers"
+description: """
+[![Join the chat at https://gitter.im/mirage/ocaml-cohttp](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/mirage/ocaml-cohttp?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+
+Cohttp is an OCaml library for creating HTTP daemons. It has a portable
+HTTP parser, and implementations using various asynchronous programming
+libraries:
+
+* `Cohttp_lwt_unix` uses the [Lwt](https://ocsigen.org/lwt/) library, and
+  specifically the UNIX bindings.
+* `Cohttp_async` uses the [Async](https://realworldocaml.org/v1/en/html/concurrent-programming-with-async.html)
+  library.
+* `Cohttp_lwt` exposes an OS-independent Lwt interface, which is used
+  by the [Mirage](https://mirage.io/) interface to generate standalone
+  microkernels (use the cohttp-mirage subpackage).
+* `Cohttp_lwt_xhr` compiles to a JavaScript module that maps the Cohttp
+  calls to XMLHTTPRequests.  This is used to compile OCaml libraries like
+  the GitHub bindings to JavaScript and still run efficiently.
+
+You can implement other targets using the parser very easily. Look at the `IO`
+signature in `lib/s.mli` and implement that in the desired backend.
+
+You can activate some runtime debugging by setting `COHTTP_DEBUG` to any
+value, and all requests and responses will be written to stderr.  Further
+debugging of the connection layer can be obtained by setting `CONDUIT_DEBUG`
+to any value."""
 url {
   src: "https://github.com/mirage/ocaml-cohttp/archive/v1.1.1.tar.gz"
   checksum: [

--- a/packages/upstream/cohttp-lwt.1.1.1/opam
+++ b/packages/upstream/cohttp-lwt.1.1.1/opam
@@ -30,6 +30,32 @@ build: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+synopsis: "An OCaml library for HTTP clients and servers"
+description: """
+[![Join the chat at https://gitter.im/mirage/ocaml-cohttp](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/mirage/ocaml-cohttp?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+
+Cohttp is an OCaml library for creating HTTP daemons. It has a portable
+HTTP parser, and implementations using various asynchronous programming
+libraries:
+
+* `Cohttp_lwt_unix` uses the [Lwt](https://ocsigen.org/lwt/) library, and
+  specifically the UNIX bindings.
+* `Cohttp_async` uses the [Async](https://realworldocaml.org/v1/en/html/concurrent-programming-with-async.html)
+  library.
+* `Cohttp_lwt` exposes an OS-independent Lwt interface, which is used
+  by the [Mirage](https://mirage.io/) interface to generate standalone
+  microkernels (use the cohttp-mirage subpackage).
+* `Cohttp_lwt_xhr` compiles to a JavaScript module that maps the Cohttp
+  calls to XMLHTTPRequests.  This is used to compile OCaml libraries like
+  the GitHub bindings to JavaScript and still run efficiently.
+
+You can implement other targets using the parser very easily. Look at the `IO`
+signature in `lib/s.mli` and implement that in the desired backend.
+
+You can activate some runtime debugging by setting `COHTTP_DEBUG` to any
+value, and all requests and responses will be written to stderr.  Further
+debugging of the connection layer can be obtained by setting `CONDUIT_DEBUG`
+to any value."""
 url {
   src: "https://github.com/mirage/ocaml-cohttp/archive/v1.1.1.tar.gz"
   checksum: [

--- a/packages/upstream/cohttp.1.1.1/opam
+++ b/packages/upstream/cohttp.1.1.1/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {build & >= "1.1.0"}
   "re" {>= "1.7.2"}
-  "uri" {>= "1.9.0"}
+  "uri" {>= "1.9.0" & < "2.0.0"}
   "fieldslib"
   "sexplib"
   "ppx_fields_conv" {>= "v0.9.0"}


### PR DESCRIPTION
This adds an important version bound on uri, which prevents compilation
failures with uri 2.0.0, which is the latest upstream version.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>