### PR TITLE
Sync opam files from component repositories

### DIFF
--- a/packages/xs-extra/nbd-tool.master/opam
+++ b/packages/xs-extra/nbd-tool.master/opam
@@ -1,14 +1,14 @@
 opam-version: "2.0"
+synopsis: "Network Block Device (NBD) protocol implementation"
+description: """
+This library allows applications to export and consume block
+devices using the NBD protocol (as used by Linux, qemu etc)"""
 maintainer: "jonathan.ludlam@citrix.com"
-authors: [ "Jonathan Ludlam" "David Scott" "Thomas Sanders" ]
+authors: ["Jonathan Ludlam" "David Scott" "Thomas Sanders"]
 license: "LGPL-2 with OCaml linking exception"
+tags: ["org:mirage" "org:xapi-project"]
 homepage: "https://github.com/xapi-project/nbd"
-dev-repo: "git+https://github.com/xapi-project/nbd.git"
 bug-reports: "https://github.com/xapi-project/nbd/issues"
-build: [
-  ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name] {with-test}
-]
 depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {build}
@@ -21,7 +21,11 @@ depends: [
   "nbd-lwt-unix"
   "uri"
 ]
-tags: [ "org:mirage" "org:xapi-project" ]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git+https://github.com/xapi-project/nbd.git"
 url {
   src: "https://github.com/xapi-project/nbd/archive/master/master.tar.gz"
 }

--- a/packages/xs-extra/rrd-transport.master/opam
+++ b/packages/xs-extra/rrd-transport.master/opam
@@ -2,7 +2,7 @@ opam-version: "2.0"
 maintainer: "xen-api@lists.xen.org"
 authors: "John Else"
 homepage: "https://github.com/xapi-project/rrd-transport"
-dev-repo: "https://github.com/xapi-project/rrd-transport"
+dev-repo: "git+https://github.com/xapi-project/rrd-transport.git"
 bug-reports: "https://github.com/xapi-project/rrd-transport"
 build: [
   ["jbuilder" "build" "-p" name "-j" jobs]

--- a/packages/xs-extra/xapi-storage-cli.master/opam
+++ b/packages/xs-extra/xapi-storage-cli.master/opam
@@ -11,9 +11,10 @@ depends: [
   "ocaml"
   "jbuilder" {build}
   "base-threads"
-  "xapi-idl"
   "re"
-  "rpc"
+  "rpclib"
+  "ppx_deriving_rpc"
+  "xcp"
   "cmdliner"
 ]
 synopsis: "A CLI for xapi storage services."

--- a/packages/xs-extra/xapi-storage.master/opam
+++ b/packages/xs-extra/xapi-storage.master/opam
@@ -13,6 +13,10 @@ depends: [
   "ocaml"
   "jbuilder" {build}
   "ounit" {with-test}
+  "alcotest" {with-test}
+  "lwt" {with-test}
+  "rpclib" {with-test}
+  "ppx_deriving_rpc" {with-test}
   "rpc"
   "xmlm"
   "cmdliner"

--- a/packages/xs-extra/xen-api-sdk.master/opam
+++ b/packages/xs-extra/xen-api-sdk.master/opam
@@ -1,15 +1,18 @@
 opam-version: "2.0"
 name: "xen-api-sdk"
+synopsis: "Xen API SDK generation code."
 maintainer: "xen-api@lists.xen.org"
 authors: [ "xen-api@lists.xen.org" ]
 license: "BSD 2-Clause"
 homepage: "https://github.com/xapi-project/xen-api-sdk"
 bug-reports: "https://github.com/xapi-project/xen-api-sdk/issues"
 dev-repo: "git+https://github.com/xapi-project/xen-api-sdk.git"
+url {
+  src: "https://github.com/xapi-project/xen-api-sdk/archive/master.tar.gz"
+}
 tags: [ "org:xapi-project" ]
 build: [[ "dune" "build" "-p" name ]]
 depends: [
-  "ocaml"
   "dune" {build}
   "xapi-datamodel"
   "mustache"
@@ -17,7 +20,3 @@ depends: [
   "xapi-stdext-unix"
   "xapi-stdext-pervasives"
 ]
-synopsis: "Xen API SDK generation code."
-url {
-  src: "https://github.com/xapi-project/xen-api-sdk/archive/master.tar.gz"
-}


### PR DESCRIPTION
Use the same opam files as they are in the repositories of these
packages:

* packages/xs-extra/nbd-tool.master/opam
* packages/xs-extra/rrd-transport.master/opam
* packages/xs-extra/xapi-storage-cli.master/opam
* packages/xs-extra/xapi-storage.master/opam
* packages/xs-extra/xen-api-sdk.master/opam

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>