### PR TITLE
xapi-backtrace: v0.6 -> v0.7

### DIFF
--- a/packages/xs/xapi-backtrace.0.7/opam
+++ b/packages/xs/xapi-backtrace.0.7/opam
@@ -6,21 +6,21 @@ bug-reports: "https://github.com/xapi-project/backtrace/issues"
 dev-repo: "git://github.com/xapi-project/backtrace.git"
 tags: [ "org:xapi-project" ]
 
-build: ["jbuilder" "build" "-p" name "-j" jobs]
+build: ["dune" "build" "-p" name "-j" jobs]
 
 depends: [
   "ocaml"
-  "jbuilder" {build}
+  "dune" {build}
   "base-threads"
-  "sexplib"
+  "ppx_deriving_rpc"
   "ppx_sexp_conv" {>= "v0.11.0"}
-  "rpc" {>= "1.9.51"}
+  "rpclib"
 ]
 synopsis: "A simple library for recording and managing backtraces"
 description: """
 This allows backtraces from multiple processes to be combined together
 and pretty-printed."""
 url {
-  src: "https://github.com/xapi-project/backtrace/archive/v0.6.tar.gz"
-  checksum: "md5=8dad1793ae1989e551274ec68cff3c63"
+  src: "https://github.com/xapi-project/backtrace/archive/v0.7.tar.gz"
+  checksum: "md5=0c62a615ae48504e4de2c5d62ab344b5"
 }


### PR DESCRIPTION
There were commits on xapi-backtrace that were not released yet, including some dependency cleanups.
Opening this PR to see if everything else still builds with the new xapi-backtrace.