### PR TITLE
revert dune to 1.4.0: DESTDIR gets appended twice

### DIFF
--- a/packages/upstream/dune.1.4.0/opam
+++ b/packages/upstream/dune.1.4.0/opam
@@ -1,24 +1,4 @@
 opam-version: "2.0"
-maintainer: "opensource@janestreet.com"
-authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
-homepage: "https://github.com/ocaml/dune"
-bug-reports: "https://github.com/ocaml/dune/issues"
-dev-repo: "git+https://github.com/ocaml/dune.git"
-license: "MIT"
-depends: [
-  "ocaml" {>= "4.02"}
-]
-build: [
-  # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
-  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
-  ["ocaml" "bootstrap.ml"]
-  ["./boot.exe" "--release" "--subst"] {pinned}
-  ["./boot.exe" "--release" "-j" jobs]
-]
-conflicts: [
-  "jbuilder" {!= "transition"}
-]
-
 synopsis: "Fast, portable and opinionated build system"
 description: """
 dune is a build system that was designed to simplify the release of
@@ -36,9 +16,26 @@ repositories into the same directory.
 It also supports multi-context builds, such as building against
 several opam roots/switches simultaneously. This helps maintaining
 packages across several versions of OCaml and gives cross-compilation
-for free.
-"""
+for free."""
+maintainer: "opensource@janestreet.com"
+authors: "Jane Street Group, LLC <opensource@janestreet.com>"
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "ocaml" {>= "4.02"}
+]
+conflicts: [
+  "jbuilder" {!= "transition"}
+]
+build: [
+  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
+  ["ocaml" "bootstrap.ml"]
+  ["./boot.exe" "--release" "--subst"] {pinned}
+  ["./boot.exe" "--release" "-j" jobs]
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
 url {
-  src: "https://github.com/ocaml/dune/releases/download/1.5.1/dune-1.5.1.tbz"
-  checksum: "md5=071ff387b85e08bdfd49dee728dc8358"
+  src: "https://github.com/ocaml/dune/releases/download/1.4.0/dune-1.4.0.tbz"
+  checksum: "md5=dc862e5d821ff4d8bef16a78bd472431"
 }


### PR DESCRIPTION
Dune now supports DESTDIR, which means that it prepends it to all paths.
Our makefiles were already prepending DESTDIR so this breaks the RPM
builds.

Revert dune update until we fix the Makefiles: https://github.com/ocaml/dune/issues/1538

