### PR TITLE
Port to dune for message-switch-* and netdev

### DIFF
--- a/packages/xs-extra/message-switch-async.master/opam
+++ b/packages/xs-extra/message-switch-async.master/opam
@@ -12,13 +12,14 @@ build: [
 ]
 depends: [
   "ocaml"
-  "jbuilder" {build}
+  "dune" {build & >= "1.4"}
   "ocamlfind" {build}
+  "odoc" {with-doc}
   "message-switch-core"
   "cohttp-async" {>= "1.0.2"}
   "async" {>= "v0.9.0"}
 ]
-synopsis: "A simple store-and-forward message switch."
+synopsis: "A simple store-and-forward message switch"
 description: """
 The switch stores messages in queues with well-known names. Clients use
 a simple HTTP protocol to enqueue and dequeue messages."""

--- a/packages/xs-extra/message-switch-cli.master/opam
+++ b/packages/xs-extra/message-switch-cli.master/opam
@@ -12,12 +12,13 @@ build: [
 ]
 depends: [
   "ocaml"
-  "jbuilder" {build}
+  "dune" {build & >= "1.4"}
   "ocamlfind" {build}
+  "odoc" {with-doc}
   "message-switch-unix"
   "cmdliner"
 ]
-synopsis: "A simple store-and-forward message switch."
+synopsis: "A simple store-and-forward message switch"
 description: """
 The switch stores messages in queues with well-known names. Clients use
 a simple HTTP protocol to enqueue and dequeue messages."""

--- a/packages/xs-extra/message-switch-core.master/opam
+++ b/packages/xs-extra/message-switch-core.master/opam
@@ -12,8 +12,9 @@ build: [
 ]
 depends: [
   "ocaml"
-  "jbuilder" {build}
+  "dune" {build & >= "1.4"}
   "ocamlfind" {build}
+  "odoc" {with-doc}
   "astring"
   "base-unix"
   "cohttp" {>= "0.21.1"}
@@ -26,7 +27,7 @@ depends: [
   "mirage-block-unix" {>= "2.4.0"}
   "shared-block-ring" {>= "2.3.0"}
 ]
-synopsis: "A simple store-and-forward message switch."
+synopsis: "A simple store-and-forward message switch"
 description: """
 The switch stores messages in queues with well-known names. Clients use
 a simple HTTP protocol to enqueue and dequeue messages."""

--- a/packages/xs-extra/message-switch-lwt.master/opam
+++ b/packages/xs-extra/message-switch-lwt.master/opam
@@ -12,13 +12,14 @@ build: [
 ]
 depends: [
   "ocaml"
-  "jbuilder" {build}
+  "dune" {build & >= "1.4"}
   "ocamlfind" {build}
+  "odoc" {with-doc}
   "message-switch-core"
   "lwt" {>= "3.0.0"}
   "cohttp-lwt-unix"
 ]
-synopsis: "A simple store-and-forward message switch."
+synopsis: "A simple store-and-forward message switch"
 description: """
 The switch stores messages in queues with well-known names. Clients use
 a simple HTTP protocol to enqueue and dequeue messages."""

--- a/packages/xs-extra/message-switch-unix.master/opam
+++ b/packages/xs-extra/message-switch-unix.master/opam
@@ -12,11 +12,12 @@ build: [
 ]
 depends: [
   "ocaml"
-  "jbuilder" {build}
+  "dune" {build & >= "1.4"}
   "ocamlfind" {build}
+  "odoc" {with-doc}
   "message-switch-core"
 ]
-synopsis: "A simple store-and-forward message switch."
+synopsis: "A simple store-and-forward message switch"
 description: """
 The switch stores messages in queues with well-known names. Clients use
 a simple HTTP protocol to enqueue and dequeue messages."""

--- a/packages/xs-extra/message-switch.master/opam
+++ b/packages/xs-extra/message-switch.master/opam
@@ -13,8 +13,9 @@ build: [
 ]
 depends: [
   "ocaml"
-  "jbuilder" {build}
+  "dune" {build & >= "1.4"}
   "ocamlfind" {build}
+  "odoc" {with-doc}
   "message-switch-lwt"
   "message-switch-unix"
   "cmdliner"
@@ -23,7 +24,7 @@ depends: [
   "cohttp-async" {>= "1.0.2"}
   "message-switch-async" {with-test}
 ]
-synopsis: "A simple store-and-forward message switch."
+synopsis: "A simple store-and-forward message switch"
 description: """
 The switch stores messages in queues with well-known names. Clients use
 a simple HTTP protocol to enqueue and dequeue messages."""

--- a/packages/xs-extra/xapi-netdev.master/opam
+++ b/packages/xs-extra/xapi-netdev.master/opam
@@ -10,7 +10,8 @@ build: [[ "jbuilder" "build" "-p" name "-j" jobs ]]
 available: [ os = "linux" ]
 depends: [
   "ocaml"
-  "jbuilder" {build}
+  "dune" {build & >= "1.4" }
+  "odoc" {with-doc}
   "xapi-stdext-std"
   "xapi-stdext-unix"
   "forkexec"


### PR DESCRIPTION
This one goes with
- https://github.com/xapi-project/netdev/pull/11
- https://github.com/xapi-project/message-switch/pull/48

Please let me know if there  is a reason why we may be unable to deprecate xcp-inventory