### PR TITLE
Update xapi-inventory to 1.2.1

### DIFF
--- a/packages/xs/xapi-inventory.1.2.1/opam
+++ b/packages/xs/xapi-inventory.1.2.1/opam
@@ -28,6 +28,6 @@ description: """
 The inventory file provides global host identify information
 needed by multiple services."""
 url {
-  src: "https://github.com/xapi-project/xcp-inventory/archive/v1.2.0.tar.gz"
-  checksum: "md5=88e1c13e43b8028c85f37d130c00dee2"
+  src: "https://github.com/xapi-project/xcp-inventory/archive/v1.2.1.tar.gz"
+  checksum: "md5=15d24391dd45d4b318451a639c3beb46"
 }


### PR DESCRIPTION
* Ported to Dune
* xcp-inevtory is now deprecated

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>