### PR TITLE
nbd-lwt-unix: add lower bound on nbd package to ensure compatibility

### DIFF
--- a/packages/xs/nbd-lwt-unix.4.0.0+beta1/opam
+++ b/packages/xs/nbd-lwt-unix.4.0.0+beta1/opam
@@ -17,7 +17,7 @@ depends: [
   "mirage-types-lwt" {>= "3.0.0"}
   "mirage-block-lwt"
   "mirage-block-unix"
-  "nbd"
+  "nbd" {>= "4.0.0"}
   "lwt_ssl"
   "ssl"
 ]


### PR DESCRIPTION
This is to ensure that we will compile nbd-lwt-unix with a compatible
version of the nbd library. Nbd 4.0.0 has introduced some new values
that this version of nbd-lwt-unix relies on, it does not work with nbd
3.X.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>