### PR TITLE
xenctrl: add missing dependency

### DIFF
--- a/packages/xs-extra/xenctrl.master/opam
+++ b/packages/xs-extra/xenctrl.master/opam
@@ -24,6 +24,7 @@ depends: [
   "ocamlfind" {build}
   "lwt" {with-test}
   "cmdliner" {build}
+  "ocamlbuild"
 ]
 depexts: [
   ["libxen-dev" "uuid-dev"] {os-distribution = "debian"}


### PR DESCRIPTION
Add ocamlbuild as a dependency - which was missing.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>