### PR TITLE
Use new xenctrl.master

### DIFF
--- a/packages/xs-extra/xenctrl.master/opam
+++ b/packages/xs-extra/xenctrl.master/opam
@@ -1,33 +1,18 @@
 opam-version: "2.0"
-maintainer: "jonathan.ludlam@citrix.com"
-authors: "xen-devel@lists.xen.org"
-homepage: "http://www.xenproject.org/"
-bug-reports: "xen-devel@lists.xen.org"
-dev-repo: "git://github.com/xapi-project/ocaml-xen-lowlevel-libs"
-tags: [
-  "org:mirage"
-  "org:xapi-project"
-]
-build: [
-  ["./configure"]
-  [make]
-]
-install: [
-  [make "install" "BINDIR=%{bin}%"]
-]
-remove: [
-  ["./configure"]
-  [make "uninstall"]
-]
+synopsis: "Mock OCaml bindings for the Xen Hypervisor"
+maintainer: "lindig@gmail.com"
+authors: "lindig@gmail.com"
+license: "LGPL"
+homepage: "https://github.com/lindig/xenctrl"
+bug-reports: "https://github.com/lindig/xenctrl/issues"
 depends: [
-  "ocaml" {>= "4.00.0"}
-  "ocamlfind" {build}
-  "lwt" {with-test}
-  "cmdliner" {build}
-  "ocamlbuild"
+  "ocaml"
+  "dune" {build}
+  "base-unix"
 ]
+build: ["dune" "build" "-p" name "-j" jobs]
 depexts: [
-  ["libxen-dev" "uuid-dev"] {os-distribution = "debian"}
+  ["m4" "libxen-dev" "libsystemd-dev"] {os-distribution = "debian"}
   ["libxen-dev" "uuid-dev"] {os-distribution = "ubuntu"}
   ["xen-devel" "libuuid-devel"] {os-distribution = "centos"}
   ["xen-devel"] {os-distribution = "fedora"}
@@ -36,9 +21,8 @@ depexts: [
   ["xen-dom0-libs-devel" "xen-libs-devel"] {os = "xenserver"}
   ["xen-dev"] {os-distribution = "alpine"}
 ]
-synopsis:
-  "OCaml bindings for low-level xen management functions. All code developed here should be upstreamed to xen-unstable eventually."
+
+dev-repo: "git+https://github.com/lindig/xenctrl.git"
 url {
-  src:
-    "https://github.com/xapi-project/ocaml-xen-lowlevel-libs/archive/master.tar.gz"
+  src: "https://github.com/lindig/xenctrl/archive/master.tar.gz"
 }


### PR DESCRIPTION
This commit puts a new `xenctrl` into xs-opam, replacing the existing implementation under the same name. The repository for this is still in my personal github accout. We could move it later, or close this and do that first. 

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>