### PR TITLE
Release stdext 4.5.0

### DIFF
--- a/packages/xs/stdext.4.5.0/opam
+++ b/packages/xs/stdext.4.5.0/opam
@@ -33,6 +33,6 @@ This library is provided for a transitionary period only.
 No new code should use this library."""
 url {
   src:
-    "https://github.com/xapi-project/stdext/archive/v4.4.1/stdext-4.4.1.tar.gz"
-  checksum: "md5=e4140501af1811eb2c5c3312a4767ac4"
+    "https://github.com/xapi-project/stdext/archive/v4.5.0/stdext-4.5.0.tar.gz"
+  checksum: "md5=5838853646b7045972417444db6898ff"
 }

--- a/packages/xs/xapi-stdext-base64.4.5.0/opam
+++ b/packages/xs/xapi-stdext-base64.4.5.0/opam
@@ -11,16 +11,14 @@ build:  [[ "jbuilder" "build" "-p" name "-j" jobs ]]
 depends: [
   "ocaml"
   "jbuilder" {build}
-  "uuidm"
-  "xapi-stdext-monadic"
+  "base64"
 ]
-synopsis:
-  "A deprecated collection of utility functions - Standard library extensions"
+synopsis: "A deprecated collection of utility functions - Base64 module"
 description: """
 This library is provided for a transitionary period only.
 No new code should use this library."""
 url {
   src:
-    "https://github.com/xapi-project/stdext/archive/v4.4.1/stdext-4.4.1.tar.gz"
-  checksum: "md5=e4140501af1811eb2c5c3312a4767ac4"
+    "https://github.com/xapi-project/stdext/archive/v4.5.0/stdext-4.5.0.tar.gz"
+  checksum: "md5=5838853646b7045972417444db6898ff"
 }

--- a/packages/xs/xapi-stdext-bigbuffer.4.5.0/opam
+++ b/packages/xs/xapi-stdext-bigbuffer.4.5.0/opam
@@ -12,12 +12,12 @@ depends: [
   "ocaml"
   "jbuilder" {build}
 ]
-synopsis: "A deprecated collection of utility functions - Range module"
+synopsis: "A deprecated collection of utility functions - bigbuffer module"
 description: """
 This library is provided for a transitionary period only.
 No new code should use this library."""
 url {
   src:
-    "https://github.com/xapi-project/stdext/archive/v4.4.1/stdext-4.4.1.tar.gz"
-  checksum: "md5=e4140501af1811eb2c5c3312a4767ac4"
+    "https://github.com/xapi-project/stdext/archive/v4.5.0/stdext-4.5.0.tar.gz"
+  checksum: "md5=5838853646b7045972417444db6898ff"
 }

--- a/packages/xs/xapi-stdext-date.4.5.0/opam
+++ b/packages/xs/xapi-stdext-date.4.5.0/opam
@@ -11,13 +11,14 @@ build:  [[ "jbuilder" "build" "-p" name "-j" jobs ]]
 depends: [
   "ocaml"
   "jbuilder" {build}
+  "base-unix"
 ]
-synopsis: "A deprecated collection of utility functions - Zerocheck module"
+synopsis: "A deprecated collection of utility functions - Date module"
 description: """
 This library is provided for a transitionary period only.
 No new code should use this library."""
 url {
   src:
-    "https://github.com/xapi-project/stdext/archive/v4.4.1/stdext-4.4.1.tar.gz"
-  checksum: "md5=e4140501af1811eb2c5c3312a4767ac4"
+    "https://github.com/xapi-project/stdext/archive/v4.5.0/stdext-4.5.0.tar.gz"
+  checksum: "md5=5838853646b7045972417444db6898ff"
 }

--- a/packages/xs/xapi-stdext-deprecated.4.5.0/opam
+++ b/packages/xs/xapi-stdext-deprecated.4.5.0/opam
@@ -11,14 +11,13 @@ build:  [[ "jbuilder" "build" "-p" name "-j" jobs ]]
 depends: [
   "ocaml"
   "jbuilder" {build}
-  "base-unix"
 ]
-synopsis: "A deprecated collection of utility functions - Date module"
+synopsis: "A deprecated collection of utility functions - Deprecated modules"
 description: """
 This library is provided for a transitionary period only.
 No new code should use this library."""
 url {
   src:
-    "https://github.com/xapi-project/stdext/archive/v4.4.1/stdext-4.4.1.tar.gz"
-  checksum: "md5=e4140501af1811eb2c5c3312a4767ac4"
+    "https://github.com/xapi-project/stdext/archive/v4.5.0/stdext-4.5.0.tar.gz"
+  checksum: "md5=5838853646b7045972417444db6898ff"
 }

--- a/packages/xs/xapi-stdext-encodings.4.5.0/opam
+++ b/packages/xs/xapi-stdext-encodings.4.5.0/opam
@@ -18,6 +18,6 @@ This library is provided for a transitionary period only.
 No new code should use this library."""
 url {
   src:
-    "https://github.com/xapi-project/stdext/archive/v4.4.1/stdext-4.4.1.tar.gz"
-  checksum: "md5=e4140501af1811eb2c5c3312a4767ac4"
+    "https://github.com/xapi-project/stdext/archive/v4.5.0/stdext-4.5.0.tar.gz"
+  checksum: "md5=5838853646b7045972417444db6898ff"
 }

--- a/packages/xs/xapi-stdext-monadic.4.5.0/opam
+++ b/packages/xs/xapi-stdext-monadic.4.5.0/opam
@@ -12,12 +12,13 @@ depends: [
   "ocaml"
   "jbuilder" {build}
 ]
-synopsis: "A deprecated collection of utility functions - Deprecated modules"
+synopsis:
+  "A deprecated collection of utility functions - Monadic modules (Monad, Listext, Either)"
 description: """
 This library is provided for a transitionary period only.
 No new code should use this library."""
 url {
   src:
-    "https://github.com/xapi-project/stdext/archive/v4.4.1/stdext-4.4.1.tar.gz"
-  checksum: "md5=e4140501af1811eb2c5c3312a4767ac4"
+    "https://github.com/xapi-project/stdext/archive/v4.5.0/stdext-4.5.0.tar.gz"
+  checksum: "md5=5838853646b7045972417444db6898ff"
 }

--- a/packages/xs/xapi-stdext-pervasives.4.5.0/opam
+++ b/packages/xs/xapi-stdext-pervasives.4.5.0/opam
@@ -11,14 +11,16 @@ build:  [[ "jbuilder" "build" "-p" name "-j" jobs ]]
 depends: [
   "ocaml"
   "jbuilder" {build}
-  "base64"
+  "logs"
+  "xapi-backtrace"
 ]
-synopsis: "A deprecated collection of utility functions - Base64 module"
+synopsis:
+  "A deprecated collection of utility functions - Pervasives extension"
 description: """
 This library is provided for a transitionary period only.
 No new code should use this library."""
 url {
   src:
-    "https://github.com/xapi-project/stdext/archive/v4.4.1/stdext-4.4.1.tar.gz"
-  checksum: "md5=e4140501af1811eb2c5c3312a4767ac4"
+    "https://github.com/xapi-project/stdext/archive/v4.5.0/stdext-4.5.0.tar.gz"
+  checksum: "md5=5838853646b7045972417444db6898ff"
 }

--- a/packages/xs/xapi-stdext-range.4.5.0/opam
+++ b/packages/xs/xapi-stdext-range.4.5.0/opam
@@ -11,17 +11,13 @@ build:  [[ "jbuilder" "build" "-p" name "-j" jobs ]]
 depends: [
   "ocaml"
   "jbuilder" {build}
-  "base-threads"
-  "base-unix"
-  "xapi-stdext-pervasives"
 ]
-synopsis:
-  "A deprecated collection of utility functions - Threads extensions and Semaphore"
+synopsis: "A deprecated collection of utility functions - Range module"
 description: """
 This library is provided for a transitionary period only.
 No new code should use this library."""
 url {
   src:
-    "https://github.com/xapi-project/stdext/archive/v4.4.1/stdext-4.4.1.tar.gz"
-  checksum: "md5=e4140501af1811eb2c5c3312a4767ac4"
+    "https://github.com/xapi-project/stdext/archive/v4.5.0/stdext-4.5.0.tar.gz"
+  checksum: "md5=5838853646b7045972417444db6898ff"
 }

--- a/packages/xs/xapi-stdext-std.4.5.0/opam
+++ b/packages/xs/xapi-stdext-std.4.5.0/opam
@@ -11,14 +11,16 @@ build:  [[ "jbuilder" "build" "-p" name "-j" jobs ]]
 depends: [
   "ocaml"
   "jbuilder" {build}
+  "uuidm"
+  "xapi-stdext-monadic"
 ]
 synopsis:
-  "A deprecated collection of utility functions - Monadic modules (Monad, Listext, Either)"
+  "A deprecated collection of utility functions - Standard library extensions"
 description: """
 This library is provided for a transitionary period only.
 No new code should use this library."""
 url {
   src:
-    "https://github.com/xapi-project/stdext/archive/v4.4.1/stdext-4.4.1.tar.gz"
-  checksum: "md5=e4140501af1811eb2c5c3312a4767ac4"
+    "https://github.com/xapi-project/stdext/archive/v4.5.0/stdext-4.5.0.tar.gz"
+  checksum: "md5=5838853646b7045972417444db6898ff"
 }

--- a/packages/xs/xapi-stdext-threads.4.5.0/opam
+++ b/packages/xs/xapi-stdext-threads.4.5.0/opam
@@ -11,13 +11,17 @@ build:  [[ "jbuilder" "build" "-p" name "-j" jobs ]]
 depends: [
   "ocaml"
   "jbuilder" {build}
+  "base-threads"
+  "base-unix"
+  "xapi-stdext-pervasives"
 ]
-synopsis: "A deprecated collection of utility functions - bigbuffer module"
+synopsis:
+  "A deprecated collection of utility functions - Threads extensions and Semaphore"
 description: """
 This library is provided for a transitionary period only.
 No new code should use this library."""
 url {
   src:
-    "https://github.com/xapi-project/stdext/archive/v4.4.1/stdext-4.4.1.tar.gz"
-  checksum: "md5=e4140501af1811eb2c5c3312a4767ac4"
+    "https://github.com/xapi-project/stdext/archive/v4.5.0/stdext-4.5.0.tar.gz"
+  checksum: "md5=5838853646b7045972417444db6898ff"
 }

--- a/packages/xs/xapi-stdext-unix.4.5.0/opam
+++ b/packages/xs/xapi-stdext-unix.4.5.0/opam
@@ -11,16 +11,18 @@ build:  [[ "jbuilder" "build" "-p" name "-j" jobs ]]
 depends: [
   "ocaml"
   "jbuilder" {build}
-  "logs"
-  "xapi-backtrace"
+  "base-unix"
+  "fd-send-recv" {>= "2.0.0"}
+  "xapi-stdext-pervasives"
+  "xapi-stdext-std"
 ]
 synopsis:
-  "A deprecated collection of utility functions - Pervasives extension"
+  "A deprecated collection of utility functions - Unix module extensions"
 description: """
 This library is provided for a transitionary period only.
 No new code should use this library."""
 url {
   src:
-    "https://github.com/xapi-project/stdext/archive/v4.4.1/stdext-4.4.1.tar.gz"
-  checksum: "md5=e4140501af1811eb2c5c3312a4767ac4"
+    "https://github.com/xapi-project/stdext/archive/v4.5.0/stdext-4.5.0.tar.gz"
+  checksum: "md5=5838853646b7045972417444db6898ff"
 }

--- a/packages/xs/xapi-stdext-zerocheck.4.5.0/opam
+++ b/packages/xs/xapi-stdext-zerocheck.4.5.0/opam
@@ -11,18 +11,13 @@ build:  [[ "jbuilder" "build" "-p" name "-j" jobs ]]
 depends: [
   "ocaml"
   "jbuilder" {build}
-  "base-unix"
-  "fd-send-recv" {>= "2.0.0"}
-  "xapi-stdext-pervasives"
-  "xapi-stdext-std"
 ]
-synopsis:
-  "A deprecated collection of utility functions - Unix module extensions"
+synopsis: "A deprecated collection of utility functions - Zerocheck module"
 description: """
 This library is provided for a transitionary period only.
 No new code should use this library."""
 url {
   src:
-    "https://github.com/xapi-project/stdext/archive/v4.4.1/stdext-4.4.1.tar.gz"
-  checksum: "md5=e4140501af1811eb2c5c3312a4767ac4"
+    "https://github.com/xapi-project/stdext/archive/v4.5.0/stdext-4.5.0.tar.gz"
+  checksum: "md5=5838853646b7045972417444db6898ff"
 }


### PR DESCRIPTION
Also rename all aliases to use the same version number as the underlying
code base.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>