### PR TITLE
Prepare for xxhash external dependency

### DIFF
--- a/packages/xs-extra/xapi.master/opam
+++ b/packages/xs-extra/xapi.master/opam
@@ -60,9 +60,9 @@ depends: [
   "zstd"
 ]
 depexts: [
-  ["hwdata" "libpci-dev" "libpam-dev"] {os-distribution = "debian"}
-  ["hwdata" "libpci-dev" "libpam-dev"] {os-distribution = "ubuntu"}
-  ["hwdata" "pciutils-devel" "pam-devel"] {os-distribution = "centos"}
+  ["hwdata" "libpci-dev" "libpam-dev" "libxxhash-dev" "libxxhash0"] {os-distribution = "debian"}
+  ["hwdata" "libpci-dev" "libpam-dev" "libxxhash-dev" "libxxhash0"] {os-distribution = "ubuntu"}
+  ["hwdata" "pciutils-devel" "pam-devel" "xxhash-devel" "xxhash-libs"] {os-distribution = "centos"}
 ]
 synopsis: "The xapi toolstack daemon which implements the XenAPI"
 description: """

--- a/tools/travis.sh
+++ b/tools/travis.sh
@@ -6,7 +6,7 @@
 
 set -e
 
-IMG='ocaml/opam2:debian-9-ocaml-4.07'
+IMG='ocaml/opam2:debian-unstable'
 
 docker pull $IMG
 docker run --rm -iv $PWD:/mnt $IMG <<'EOF'

--- a/tools/travis.sh
+++ b/tools/travis.sh
@@ -16,6 +16,7 @@ sudo apt-get update
 opam repo remove --all default
 opam repo add xs-opam file:///mnt
 opam depext -vv -y xs-toolstack
+opam switch 4.07
 opam install -j $(getconf _NPROCESSORS_ONLN) xs-toolstack
 EOF
 


### PR DESCRIPTION
Xapi will soon gain xxhash as a new external dependency. it is not yet available in the current distribution we use for builds on Travis. Therefore:

* record the dependency in xapi's opam file
* use debian-unstable for Travis

