### PR TITLE
CA-318579 update qmp to 0.18.0 for "query-chardev"

### DIFF
--- a/packages/xs/qmp.0.18.0/opam
+++ b/packages/xs/qmp.0.18.0/opam
@@ -22,6 +22,5 @@ depends: [
 dev-repo: "git://github.com/xapi-project/ocaml-qmp"
 synopsis: "OCaml implementation of a Qemu Message Protocol (QMP) client"
 url {
-  src: "https://github.com/xapi-project/ocaml-qmp/archive/v0.17.0.tar.gz"
-  checksum: "md5=807876528c442844a8d754936e600ff1"
-}
+  src: "https://github.com/xapi-project/ocaml-qmp/archive/v0.18.0.tar.gz"
+  checksum: "md5=9b9fb2a383a12ae7b430cf5ba9983155"}


### PR DESCRIPTION
Update to qmp for added query-chardev command.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>