### PR TITLE
REQ-627 set up feature branch

### DIFF
--- a/packages/xs-extra/xapi-cli-protocol.req-627/opam
+++ b/packages/xs-extra/xapi-cli-protocol.req-627/opam
@@ -9,12 +9,9 @@ build: [[ "dune" "build" "-p" name ]]
 depends: [
   "ocaml"
   "dune" {build & >= "1.4"}
-  "stunnel"
   "base-threads"
-  "xapi-cli-protocol"
   "xapi-consts"
   "xapi-datamodel"
-  "xapi-stdext-pervasives"
   "xapi-stdext-std"
   "xapi-stdext-unix"
 ]
@@ -23,5 +20,5 @@ description: """
 This daemon exposes the XenAPI and is used by clients such as 'xe'
 and 'XenCenter' to manage clusters of Xen-enabled hosts."""
 url {
-  src: "https://github.com/xapi-project/xen-api/archive/master/master.tar.gz"
+  src: "https://github.com/xapi-project/xen-api/archive/REQ-627/REQ-627.tar.gz"
 }

--- a/packages/xs-extra/xapi-client.req-627/opam
+++ b/packages/xs-extra/xapi-client.req-627/opam
@@ -26,5 +26,5 @@ description: """
 This daemon exposes the XenAPI and is used by clients such as 'xe'
 and 'XenCenter' to manage clusters of Xen-enabled hosts."""
 url {
-  src: "https://github.com/xapi-project/xen-api/archive/master/master.tar.gz"
+  src: "https://github.com/xapi-project/xen-api/archive/REQ-627/REQ-627.tar.gz"
 }

--- a/packages/xs-extra/xapi-consts.req-627/opam
+++ b/packages/xs-extra/xapi-consts.req-627/opam
@@ -9,27 +9,11 @@ build: [[ "dune" "build" "-p" name ]]
 depends: [
   "ocaml"
   "dune" {build & >= "1.4"}
-  "astring"
-  "http-svr"
-  "ocaml-migrate-parsetree"
-  "ppx_deriving_rpc"
-  "rpclib"
-  "sexpr"
-  "base-threads"
-  "uuid"
-  "uuidm"
-  "xapi-consts"
-  "xapi-datamodel"
-  "xapi-stdext-date"
-  "xapi-stdext-pervasives"
-  "xapi-stdext-std"
-  "xapi-stdext-unix"
-  "xapi-idl"
 ]
 synopsis: "The xapi toolstack daemon which implements the XenAPI"
 description: """
 This daemon exposes the XenAPI and is used by clients such as 'xe'
 and 'XenCenter' to manage clusters of Xen-enabled hosts."""
 url {
-  src: "https://github.com/xapi-project/xen-api/archive/master/master.tar.gz"
+  src: "https://github.com/xapi-project/xen-api/archive/REQ-627/REQ-627.tar.gz"
 }

--- a/packages/xs-extra/xapi-database.req-627/opam
+++ b/packages/xs-extra/xapi-database.req-627/opam
@@ -9,16 +9,28 @@ build: [[ "dune" "build" "-p" name ]]
 depends: [
   "ocaml"
   "dune" {build & >= "1.4"}
+  "gzip"
+  "http-svr"
+  "ocaml-migrate-parsetree"
+  "ounit"
+  "ppx_deriving_rpc"
+  "ppx_sexp_conv"
+  "rpclib"
+  "sexpr"
   "base-threads"
-  "xapi-consts"
-  "xapi-datamodel"
+  "uuid"
+  "xapi-stdext-encodings"
+  "xapi-stdext-monadic"
+  "xapi-stdext-pervasives"
   "xapi-stdext-std"
+  "xapi-stdext-threads"
   "xapi-stdext-unix"
+  "xapi-idl"
 ]
 synopsis: "The xapi toolstack daemon which implements the XenAPI"
 description: """
 This daemon exposes the XenAPI and is used by clients such as 'xe'
 and 'XenCenter' to manage clusters of Xen-enabled hosts."""
 url {
-  src: "https://github.com/xapi-project/xen-api/archive/master/master.tar.gz"
+  src: "https://github.com/xapi-project/xen-api/archive/REQ-627/REQ-627.tar.gz"
 }

--- a/packages/xs-extra/xapi-datamodel.req-627/opam
+++ b/packages/xs-extra/xapi-datamodel.req-627/opam
@@ -26,5 +26,5 @@ description: """
 This daemon exposes the XenAPI and is used by clients such as 'xe'
 and 'XenCenter' to manage clusters of Xen-enabled hosts."""
 url {
-  src: "https://github.com/xapi-project/xen-api/archive/master/master.tar.gz"
+  src: "https://github.com/xapi-project/xen-api/archive/REQ-627/REQ-627.tar.gz"
 }

--- a/packages/xs-extra/xapi-idl.req-627/opam
+++ b/packages/xs-extra/xapi-idl.req-627/opam
@@ -45,5 +45,5 @@ The xapi toolstack is a set of communicating services including
   - rrdd: manages datasources and records history
 plus storage 'plugins'"""
 url {
-  src: "https://github.com/xapi-project/xcp-idl/archive/master.tar.gz"
+  src: "https://github.com/xapi-project/xcp-idl/archive/REQ-627.tar.gz"
 }

--- a/packages/xs-extra/xapi-types.req-627/opam
+++ b/packages/xs-extra/xapi-types.req-627/opam
@@ -9,21 +9,20 @@ build: [[ "dune" "build" "-p" name ]]
 depends: [
   "ocaml"
   "dune" {build & >= "1.4"}
-  "gzip"
+  "astring"
   "http-svr"
   "ocaml-migrate-parsetree"
-  "ounit"
   "ppx_deriving_rpc"
-  "ppx_sexp_conv"
   "rpclib"
   "sexpr"
   "base-threads"
   "uuid"
-  "xapi-stdext-encodings"
-  "xapi-stdext-monadic"
+  "uuidm"
+  "xapi-consts"
+  "xapi-datamodel"
+  "xapi-stdext-date"
   "xapi-stdext-pervasives"
   "xapi-stdext-std"
-  "xapi-stdext-threads"
   "xapi-stdext-unix"
   "xapi-idl"
 ]
@@ -32,5 +31,5 @@ description: """
 This daemon exposes the XenAPI and is used by clients such as 'xe'
 and 'XenCenter' to manage clusters of Xen-enabled hosts."""
 url {
-  src: "https://github.com/xapi-project/xen-api/archive/master/master.tar.gz"
+  src: "https://github.com/xapi-project/xen-api/archive/REQ-627/REQ-627.tar.gz"
 }

--- a/packages/xs-extra/xapi-xenopsd-simulator.req-627/opam
+++ b/packages/xs-extra/xapi-xenopsd-simulator.req-627/opam
@@ -19,5 +19,5 @@ depends: [
 synopsis:
   "Simulation backend allowing testing of the higher-level xenops logic."
 url {
-  src: "https://github.com/xapi-project/xenopsd/archive/master/master.tar.gz"
+  src: "https://github.com/xapi-project/xenopsd/archive/REQ-627/REQ-627.tar.gz"
 }

--- a/packages/xs-extra/xapi-xenopsd-xc.req-627/opam
+++ b/packages/xs-extra/xapi-xenopsd-xc.req-627/opam
@@ -41,5 +41,5 @@ synopsis:
   "A xenops plugin which knows how to use xenstore, xenctrl and xenguest to manage"
 description: "VMs on a xen host."
 url {
-  src: "https://github.com/xapi-project/xenopsd/archive/master/master.tar.gz"
+  src: "https://github.com/xapi-project/xenopsd/archive/REQ-627/REQ-627.tar.gz"
 }

--- a/packages/xs-extra/xapi-xenopsd.req-627/opam
+++ b/packages/xs-extra/xapi-xenopsd.req-627/opam
@@ -40,5 +40,5 @@ via a simple API. The API has been tailored to suit the needs of xapi,
 which manages clusters of hosts running Xen, but it can also be used
 standalone."""
 url {
-  src: "https://github.com/xapi-project/xenopsd/archive/master/master.tar.gz"
+  src: "https://github.com/xapi-project/xenopsd/archive/REQ-627/REQ-627.tar.gz"
 }

--- a/packages/xs-extra/xapi.req-627/opam
+++ b/packages/xs-extra/xapi.req-627/opam
@@ -69,5 +69,5 @@ description: """
 This daemon exposes the XenAPI and is used by clients such as 'xe'
 and 'XenCenter' to manage clusters of Xen-enabled hosts."""
 url {
-  src: "https://github.com/xapi-project/xen-api/archive/master/master.tar.gz"
+  src: "https://github.com/xapi-project/xen-api/archive/REQ-627/REQ-627.tar.gz"
 }

--- a/packages/xs-extra/xe.req-627/opam
+++ b/packages/xs-extra/xe.req-627/opam
@@ -9,11 +9,19 @@ build: [[ "dune" "build" "-p" name ]]
 depends: [
   "ocaml"
   "dune" {build & >= "1.4"}
+  "stunnel"
+  "base-threads"
+  "xapi-cli-protocol"
+  "xapi-consts"
+  "xapi-datamodel"
+  "xapi-stdext-pervasives"
+  "xapi-stdext-std"
+  "xapi-stdext-unix"
 ]
 synopsis: "The xapi toolstack daemon which implements the XenAPI"
 description: """
 This daemon exposes the XenAPI and is used by clients such as 'xe'
 and 'XenCenter' to manage clusters of Xen-enabled hosts."""
 url {
-  src: "https://github.com/xapi-project/xen-api/archive/master/master.tar.gz"
+  src: "https://github.com/xapi-project/xen-api/archive/REQ-627/REQ-627.tar.gz"
 }


### PR DESCRIPTION
Set up a feature branch where the following components track the HEAD
for branch REQ-627 instead of master:

* xapi-client.req-627
* xapi-consts.req-627
* xapi-database.req-627
* xapi-datamodel.req-627
* xapi-idl.req-627
* xapi-types.req-627
* xapi-xenopsd-simulator.req-627
* xapi-xenopsd-xc.req-627
* xapi-xenopsd.req-627
* xapi.req-627
* xe.req-627

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>