### PR TITLE
xs-toolstack: remove unused xapi-netdev dependency

### DIFF
--- a/packages/xs-extra-dummy/xs-toolstack.master/opam
+++ b/packages/xs-extra-dummy/xs-toolstack.master/opam
@@ -35,7 +35,6 @@ depends: [
   "xapi-idl"
   "xapi-libs-transitional"
   "xapi-nbd"
-  "xapi-netdev"
   "xapi-networkd"
   "xapi-plugin"
   "xapi-rrdd"


### PR DESCRIPTION
Signed-off-by: Rob Hoes <rob.hoes@citrix.com>