### PR TITLE
xcp-rrd update to 1.6.0 for CA-322008

### DIFF
--- a/packages/xs/xapi-rrd.1.6.0/opam
+++ b/packages/xs/xapi-rrd.1.6.0/opam
@@ -29,6 +29,6 @@ Round-Robin Databases (RRDs) are constant-space datastructures
 used for archiving historical data where the older data is stored
 at a lower resolution."""
 url {
-  src: "https://github.com/xapi-project/xcp-rrd/archive/v1.5.0.tar.gz"
-  checksum: "md5=7d0a16090d508d25c883bbcdc4726632"
+  src: "https://github.com/xapi-project/xcp-rrd/archive/v1.6.0.tar.gz"
+  checksum: "md5=cf0585e055365404513235a1bd330a98"
 }


### PR DESCRIPTION
* 4a86fb5 CA-322008: Report out-of-bounds PDP values as NaN
* 67ea741 maintenance: whitespace and commented code deletion
* 3103ae6 maintenance: use infix operators for Int64 in rrd
* 9718e95 CA-322008: Reorganize code for incoming values by type
* c986340 CA-322008: do not treat DERIVE sources as COUNTER
* b028c29 tests: add regression test for CA-322008

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>