### PR TITLE
CA-324944, CA-297060 patch Core for timing functions

### DIFF
--- a/packages/upstream/core.113.33.03/files/ca-297060.patch
+++ b/packages/upstream/core.113.33.03/files/ca-297060.patch
@@ -1,0 +1,12 @@
+diff -ur core.113.33.03-b/src/time_stamp_counter.ml core.113.33.03-a/src/time_stamp_counter.ml
+--- core.113.33.03-b/src/time_stamp_counter.ml	2018-08-28 10:16:58.000000000 +0100
++++ core.113.33.03-a/src/time_stamp_counter.ml	2018-10-08 14:16:58.079842519 +0100
+@@ -156,7 +156,7 @@
+      the duration of time, i.e. longer time samples are given more weight and shorter time
+      samples are given lesser weight. *)
+   let alpha_for_interval time_diff =
+-    1. -. exp (-0.5 *. time_diff)
++    Float.max 0.0 (1. -. exp (-0.5 *. time_diff))
+   ;;
+ 
+   let catchup_cycles                  = 1E9

--- a/packages/upstream/core.113.33.03/opam
+++ b/packages/upstream/core.113.33.03/opam
@@ -5,6 +5,7 @@ homepage: "https://github.com/janestreet/core"
 bug-reports: "https://github.com/janestreet/core/issues"
 dev-repo: "https://github.com/janestreet/core.git"
 license: "Apache-2.0"
+patches: [ "ca-297060.patch" ]
 build: [
   ["./configure" "--prefix" prefix]
   [make]


### PR DESCRIPTION
Backport this to avoid spending time on every hotfix confirming that it is the same coredump we know about:

We observe core dumps in xapi-storage-script when the clock is reset
during testing. Communication with upstream suggests that this is a bug
which this commit fixes by putting in a patch.

* https://github.com/janestreet/core/issues/119

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>
(cherry picked from commit a284382c46714e44225fe72df49debd913154b9c)
Signed-off-by: Edwin Török <edvin.torok@citrix.com>

