### PR TITLE
xs-extra: update opam files from repos

### DIFF
--- a/packages/xs-extra/http-svr.master/opam
+++ b/packages/xs-extra/http-svr.master/opam
@@ -14,7 +14,6 @@ depends: [
   "dune" {build}
   "astring"
   "base64" {>= "3.1.0"}
-  "ppx_deriving_rpc"
   "rpclib"
   "sha"
   "stunnel"

--- a/packages/xs-extra/message-switch-async.master/opam
+++ b/packages/xs-extra/message-switch-async.master/opam
@@ -8,16 +8,15 @@ dev-repo: "git://github.com/xapi-project/message-switch"
 tags: [ "org:xapi-project" ]
 build: [
   ["./configure" "--bindir" "%{bin}%"]
-  [ "jbuilder" "build" "-p" name "-j" jobs ]
+  [ "dune" "build" "-p" name "-j" jobs ]
 ]
 depends: [
   "ocaml"
   "dune" {build & >= "1.4"}
-  "ocamlfind" {build}
   "odoc" {with-doc}
-  "message-switch-core"
-  "cohttp-async" {>= "1.0.2"}
   "async" {>= "v0.9.0"}
+  "cohttp-async" {>= "1.0.2"}
+  "message-switch-core"
 ]
 synopsis: "A simple store-and-forward message switch"
 description: """

--- a/packages/xs-extra/message-switch-cli.master/opam
+++ b/packages/xs-extra/message-switch-cli.master/opam
@@ -8,15 +8,15 @@ dev-repo: "git://github.com/xapi-project/message-switch"
 tags: [ "org:xapi-project" ]
 build: [
   ["./configure" "--bindir" "%{bin}%"]
-  [ "jbuilder" "build" "-p" name "-j" jobs ]
+  [ "dune" "build" "-p" name "-j" jobs ]
 ]
 depends: [
   "ocaml"
   "dune" {build & >= "1.4"}
-  "ocamlfind" {build}
   "odoc" {with-doc}
-  "message-switch-unix"
   "cmdliner"
+  "message-switch-unix"
+  "ppx_deriving_rpc"
 ]
 synopsis: "A simple store-and-forward message switch"
 description: """

--- a/packages/xs-extra/message-switch-core.master/opam
+++ b/packages/xs-extra/message-switch-core.master/opam
@@ -8,24 +8,18 @@ dev-repo: "git://github.com/xapi-project/message-switch"
 tags: [ "org:xapi-project" ]
 build: [
   ["./configure" "--bindir" "%{bin}%"]
-  [ "jbuilder" "build" "-p" name "-j" jobs ]
+  [ "dune" "build" "-p" name "-j" jobs ]
 ]
 depends: [
   "ocaml"
   "dune" {build & >= "1.4"}
-  "ocamlfind" {build}
   "odoc" {with-doc}
   "astring"
-  "base-unix"
   "cohttp" {>= "0.21.1"}
-  "ocaml-migrate-parsetree"
   "ppx_deriving_rpc"
   "ppx_sexp_conv"
   "rpclib"
   "sexplib"
-  "mtime" {>= "1.0.0" & < "2.0.0"}
-  "mirage-block-unix" {>= "2.4.0"}
-  "shared-block-ring" {>= "2.3.0"}
 ]
 synopsis: "A simple store-and-forward message switch"
 description: """

--- a/packages/xs-extra/message-switch-lwt.master/opam
+++ b/packages/xs-extra/message-switch-lwt.master/opam
@@ -8,16 +8,15 @@ dev-repo: "git://github.com/xapi-project/message-switch"
 tags: [ "org:xapi-project" ]
 build: [
   ["./configure" "--bindir" "%{bin}%"]
-  [ "jbuilder" "build" "-p" name "-j" jobs ]
+  [ "dune" "build" "-p" name "-j" jobs ]
 ]
 depends: [
   "ocaml"
   "dune" {build & >= "1.4"}
-  "ocamlfind" {build}
   "odoc" {with-doc}
-  "message-switch-core"
-  "lwt" {>= "3.0.0"}
   "cohttp-lwt-unix"
+  "lwt" {>= "3.0.0"}
+  "message-switch-core"
 ]
 synopsis: "A simple store-and-forward message switch"
 description: """

--- a/packages/xs-extra/message-switch-unix.master/opam
+++ b/packages/xs-extra/message-switch-unix.master/opam
@@ -8,14 +8,15 @@ dev-repo: "git://github.com/xapi-project/message-switch"
 tags: [ "org:xapi-project" ]
 build: [
   ["./configure" "--bindir" "%{bin}%"]
-  [ "jbuilder" "build" "-p" name "-j" jobs ]
+  [ "dune" "build" "-p" name "-j" jobs ]
 ]
 depends: [
   "ocaml"
   "dune" {build & >= "1.4"}
-  "ocamlfind" {build}
   "odoc" {with-doc}
+  "base-threads"
   "message-switch-core"
+  "ppx_deriving_rpc"
 ]
 synopsis: "A simple store-and-forward message switch"
 description: """

--- a/packages/xs-extra/message-switch.master/opam
+++ b/packages/xs-extra/message-switch.master/opam
@@ -8,21 +8,27 @@ dev-repo: "git://github.com/xapi-project/message-switch"
 tags: [ "org:xapi-project" ]
 build: [
   ["./configure" "--bindir" "%{bin}%"]
-  ["jbuilder" "build" "-p" name "-j" jobs]
-  ["jbuilder" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
   "ocaml"
   "dune" {build & >= "1.4"}
-  "ocamlfind" {build}
   "odoc" {with-doc}
-  "message-switch-lwt"
-  "message-switch-unix"
   "cmdliner"
+  "cohttp-async" {with-test}
   "cohttp-lwt-unix"
   "io-page-unix"
-  "cohttp-async" {>= "1.0.2"}
+  "lwt_log"
   "message-switch-async" {with-test}
+  "message-switch-lwt"
+  "message-switch-unix"
+  "mirage-block-unix" {>= "2.4.0"}
+  "mtime" {>= "1.0.0" & < "2.0.0"}
+  "ppx_deriving_rpc" {with-test}
+  "ppx_sexp_conv"
+  "sexplib"
+  "shared-block-ring" {>= "2.3.0"}
 ]
 synopsis: "A simple store-and-forward message switch"
 description: """

--- a/packages/xs-extra/rrd-transport.master/opam
+++ b/packages/xs-extra/rrd-transport.master/opam
@@ -14,12 +14,12 @@ depends: [
   "cstruct"
   "crc"
   "astring"
+  "ezjsonm"
   "xapi-idl" {>= "1.0.0"}
   "xapi-rrd" {>= "1.0.0"}
   "xen-gnt" {>= "3.0.0"}
   "xen-gnt-unix" {>= "3.0.0"}
   "ounit" {with-test}
-  "ezjsonm"
 ]
 synopsis: "Shared-memory protocols for exposing performance counters"
 description: """

--- a/packages/xs-extra/rrd2csv.master/opam
+++ b/packages/xs-extra/rrd2csv.master/opam
@@ -1,15 +1,19 @@
+
 opam-version: "2.0"
 name: "rrd2csv"
 maintainer: "opam-devel@lists.ocaml.org"
 authors: [ "Guillem Rieu" ]
 license: "LGPL-2.1 with OCaml linking exception"
+homepage: "https://github.com/xenserver/rrd2csv"
+bug-reports: "https://github.com/xenserver/rrd2csv/issues"
+dev-repo: "git+https://github.com/xenserver/rrd2csv.git"
 build: [
-  ["jbuilder" "build" "-p" name "-j" jobs]
-  ["jbuilder" "runtest" "-p" name] {with-test}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
 ]
 depends: [
   "ocaml"
-  "jbuilder" {build}
+  "dune" {build}
   "base-threads"
   "xapi-client"
   "xapi-idl"

--- a/packages/xs-extra/rrdd-plugin.master/opam
+++ b/packages/xs-extra/rrdd-plugin.master/opam
@@ -9,7 +9,6 @@ depends: [
   "ocaml"
   "dune" {build & >= "1.0+beta10"}
   "astring"
-  "ppx_deriving_rpc"
   "rpclib"
   "xapi-forkexecd"
   "xapi-stdext-pervasives"

--- a/packages/xs-extra/vhd-tool.master/opam
+++ b/packages/xs-extra/vhd-tool.master/opam
@@ -14,11 +14,12 @@ depends: [
   "ocaml"
   "dune" {build}
   "cohttp-lwt"
-  "cstruct"
+  "cstruct" {>= "3.0.0"}
   "io-page"
   "lwt"
   "nbd-lwt-unix"
   "ocaml-migrate-parsetree"
+  "ppx_cstruct"
   "ppx_deriving_rpc"
   "re"
   "rpclib"

--- a/packages/xs-extra/wsproxy.master/opam
+++ b/packages/xs-extra/wsproxy.master/opam
@@ -13,7 +13,7 @@ build: [
 depends: [
   "ocaml"
   "dune" {build}
-  "base64"
+  "base64" {>= "3.1.0"}
   "lwt" {>= "3.0.0"}
   "lwt_log"
   "re"

--- a/packages/xs-extra/xapi-networkd.master/opam
+++ b/packages/xs-extra/xapi-networkd.master/opam
@@ -1,24 +1,30 @@
 opam-version: "2.0"
-maintainer: "jonathan.ludlam@eu.citrix.com"
+maintainer: "xen-api@lists.xen.org"
 authors: "jonathan.ludlam@eu.citrix.com"
 homepage: "https://github.com/xapi-project/xcp-networkd"
-
+dev-repo: "git+https://github.com/xapi-project/xcp-networkd.git"
+bug-reports: "https://github.com/xapi-project/xcp-networkd/issues"
 build: [
-  ["jbuilder" "build" "-p" name "-j" jobs]
-  ["jbuilder" "runtest" "-p" name] {with-test}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
 ]
 depends: [
-  "ocaml"
-  "jbuilder" {build}
+  "astring"          
+  "base-threads"
+  "forkexec"
+  "mtime"
   "netlink"
-  "ppx_deriving_rpc"
+  "ounit"
+  "re"
   "rpclib"
   "systemd"
-  "xapi-forkexecd"
   "xapi-idl"
   "xapi-inventory"
-  "xapi-libs-transitional"
-  "xapi-stdext" {>= "3.0.0"}
+  "xapi-stdext-monadic"
+  "xapi-stdext-pervasives"
+  "xapi-stdext-threads"
+  "xapi-stdext-unix"
+  "xapi-test-utils"
   "xen-api-client"
 ]
 synopsis: "The XCP networking daemon"

--- a/packages/xs-extra/xapi-rrdd.master/opam
+++ b/packages/xs-extra/xapi-rrdd.master/opam
@@ -1,13 +1,19 @@
 opam-version: "2.0"
 maintainer: "xen-api@lists.xen.org"
+authors:  "xen-api@lists.xen.org"
+homepage: "https://github.com/xapi-project/xcp-rrdd"
+bug-reports: "https://github.com/xapi-project/xcp-rrdd/issues"
+dev-repo: "git+https://github.com/xapi-project/xcp-rrdd.git"
 build: [
-  ["jbuilder" "build" "-p" name "-j" jobs]
-  ["jbuilder" "runtest" "-p" name] {with-test}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
 ]
 depends: [
   "ocaml" {>= "4.02.0"}
-  "jbuilder" {build & >= "1.0+beta10"}
+  "dune" {build}
   "astring"
+  "gzip"
+  "http-svr"
   "inotify"
   "io-page"
   "mtime"
@@ -15,9 +21,10 @@ depends: [
   "ppx_deriving_rpc"
   "rpclib"
   "systemd"
+  "ezxenstore"
+  "uuid"
   "xapi-backtrace"
   "xapi-idl"
-  "xapi-libs-transitional"
   "xapi-rrd"
   "xapi-rrd-transport"
   "xapi-stdext-monadic"

--- a/packages/xs-extra/xapi-squeezed.master/opam
+++ b/packages/xs-extra/xapi-squeezed.master/opam
@@ -1,13 +1,16 @@
 opam-version: "2.0"
-maintainer: "dave.scott@eu.citrix.com"
-
+author: "dave.scott@eu.citrix.com"
+maintainer: "xen-api@lists.xen.org"
+homepage: "https://github.com/xapi-project/squeezed"
+bug-reports: "https://github.com/xapi-project/squeezed/issues"
+dev-repo: "git://github.com/xapi-project/squeezed.git"
 build: [
-  ["jbuilder" "build" "-p" name "-j" jobs]
-  ["jbuilder" "runtest" "-p" name] {with-test}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
 ]
 depends: [
   "ocaml"
-  "jbuilder" {build}
+  "dune" {build}
   "uuidm"
   "xapi-stdext-monadic"
   "xapi-stdext-pervasives"

--- a/packages/xs-extra/xapi.master/opam
+++ b/packages/xs-extra/xapi.master/opam
@@ -12,6 +12,7 @@ depends: [
   "ocaml"
   "dune" {build & >= "1.4"}
   "alcotest"
+  "base64"
   "cdrom"
   "ctypes"
   "ctypes-foreign"
@@ -53,7 +54,6 @@ depends: [
   "xapi-xenopsd"
   "xapi-idl"
   "xapi-inventory"
-  "xenctrl"
   "xml-light2"
   "yojson"
   "zstd"

--- a/packages/xs-extra/xenops.master/opam
+++ b/packages/xs-extra/xenops.master/opam
@@ -4,7 +4,7 @@ authors: "xen-api@lists.xen.org"
 homepage: "https://xapi-project.github.io/"
 bug-reports: "https://github.com/xapi-project/xenops/issues"
 dev-repo: "git://github.com/xapi-project/xenops.git"
-build:  [[ "jbuilder" "build" "-p" name "-j" jobs ]]
+build:  [[ "dune" "build" "-p" name "-j" jobs ]]
 depends: [
   "ocaml" {>= "4.01.0"}
   "dune" {build}


### PR DESCRIPTION
Some files have not been pulled because of the rpc to rpclib migration, I don't know if the "ppx_deriving_rpc" are safe to remove.