### PR TITLE
tools: add env file to load xs-opam settings on travis

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,20 @@ Travis builds the entire universe represented by this Opam repository.
 [OCaml]:  http:/ocaml.org
 [Travis]: https://travis-ci.org/xapi-project/xs-opam
 
+### Using it on your travis builds
+
+Load the config on the install step for .travis-docker.sh at install time, then run the script for testing your package:
+```
+language: c
+sudo: required
+service: docker
+install:
+  - wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-docker.sh
+  - wget https://raw.githubusercontent.com/xapi-project/xs-opam/master/tools/xs-opam-ci.env
+  - source xs-opam-ci.env
+script: bash -ex .travis-docker.sh
+env:
+  global:
+    - PINS="EXAMPLE:."
+    - PACKAGE="EXAMPLE"
+```

--- a/tools/xs-opam-ci.env
+++ b/tools/xs-opam-ci.env
@@ -1,0 +1,3 @@
+export OCAML_VERSION="4.07"
+export DISTRO="debian-unstable"
+export BASE_REMOTE="https://github.com/xapi-project/xs-opam.git"


### PR DESCRIPTION
This allows us to centrally manage the docker images, ocaml version and repo branch.

Working example: https://travis-ci.com/psafont/xcp-rrd/jobs/225775235

Existing repositories can be modified progressively to adopt the new pattern