### PR TITLE
CP-32138: Add logs-syslog and dependencies

### DIFF
--- a/packages/upstream/logs-syslog.0.2.1/opam
+++ b/packages/upstream/logs-syslog.0.2.1/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/hannesm/logs-syslog"
+doc: "https://hannesm.github.io/logs-syslog/doc"
+dev-repo: "git+https://github.com/hannesm/logs-syslog.git"
+bug-reports: "https://github.com/hannesm/logs-syslog/issues"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "1.1.0"}
+  "logs"
+  "ptime"
+  "syslog-message" {>= "1.0.0"}
+]
+
+depopts: [
+  "lwt"
+  "x509" "tls" "cstruct"
+  "mirage-kv-lwt"
+  "mirage-console-lwt" "mirage-clock" "mirage-stack-lwt" "ipaddr"
+]
+
+conflicts: [
+  "mirage-types-lwt" {< "3.0.0"}
+  "x509" {< "0.6.0"}
+  "tls" {< "0.8.0"}
+]
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+
+synopsis: "Logs reporter to syslog (UDP/TCP/TLS)"
+description: """
+This library provides log reporters using syslog over various transports (UDP,
+TCP, TLS) with various effectful layers: Unix, Lwt, MirageOS.  It integrates the
+[Logs](http://erratique.ch/software/logs) library, which provides logging
+infrastructure for OCaml, with the
+[syslog-message](http://verbosemo.de/syslog-message/) library, which provides
+encoding and decoding of syslog messages ([RFC
+3164](https://tools.ietf.org/html/rfc3164)).
+"""
+url {
+  src:
+    "https://github.com/hannesm/logs-syslog/releases/download/v0.2.1/logs-syslog-v0.2.1.tbz"
+  checksum: "md5=f2af7cf3de14e2a970faf2433375270e"
+}

--- a/packages/upstream/syslog-message.1.1.0/opam
+++ b/packages/upstream/syslog-message.1.1.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "Jochen Bartl <jochenbartl@mailbox.org>"
+authors: [ "Jochen Bartl <jochenbartl@mailbox.org>" ]
+homepage: "https://github.com/verbosemode/syslog-message"
+doc: "https://verbosemode.github.io/syslog-message/doc"
+dev-repo: "git+https://github.com/verbosemode/syslog-message.git"
+bug-reports: "https://github.com/verbosemode/syslog-message/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "1.1.0"}
+  "astring"
+  "ptime"
+  "rresult"
+  "qcheck" {with-test}
+]
+
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+synopsis: "Syslog message parser"
+description: """
+This is a library for parsing and generating [RFC3164](https://tools.ietf.org/html/rfc3164)
+compatible Syslog messages.
+"""
+url {
+  src:
+    "https://github.com/verbosemode/syslog-message/releases/download/1.1.0/syslog-message-1.1.0.tbz"
+  checksum: [
+    "sha256=6f14705026aced72a7f86548d3b0ab3ead9013f3726be77f36ca092ce86cc46f"
+    "sha512=086c80acfac751efb7dcc9d8dd078cc2c38812bfcb4a0e06ae6bf1a74189d36ec130b412738cb00d12cbdb5ffdb39f4afaa12c557ed043f2b538de628c292351"
+  ]
+}


### PR DESCRIPTION
These packages facilitate https://github.com/xapi-project/message-switch/issues/39.

I still need to test my changes for message switch, but I think it's pretty certain that logs-syslog will be used in any case.

The syslog library could potentially replace our custom bindings for syslog in xcp-idl to avoid repetition (lwt_log had its own implementation as well)