### PR TITLE
Add fmt >= 0.8.8 to xapi-xenopsd

### DIFF
--- a/packages/xs-extra/xapi-xenopsd.master/opam
+++ b/packages/xs-extra/xapi-xenopsd.master/opam
@@ -31,7 +31,7 @@ depends: [
   "xapi-idl"
   "xenctrl"
   "xmlm"
-  "fmt"
+  "fmt" { >= "0.8.8" }
 ]
 synopsis: "A single-host domain/VM manager for the Xen hypervisor"
 description: """


### PR DESCRIPTION
Xenopsd depends on Dump.record from fmt which is not present in fmt
0.8.6 at least.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>