### PR TITLE
Use OCaml 4.08 by default, 4.09 speculatively

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,8 @@ matrix:
   include:
     - env: OPAMWITHTEST=false
     - env: OPAMWITHTEST=true
-    - env: OPAMWITHTEST=true OCAML_VERSION=4.08
     - env: OPAMWITHTEST=true RECURSIVE=--recursive
+    - env: OPAMWITHTEST=true OCAML_VERSION=4.09
   allow_failures:
     - env: OPAMWITHTEST=true RECURSIVE=--recursive
+    - env: OPAMWITHTEST=true OCAML_VERSION=4.09

--- a/packages/ocaml/ocaml-system.4.09.0/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml/ocaml-system.4.09.0/files/gen_ocaml_config.ml.in
@@ -1,0 +1,43 @@
+let () =
+  let exe = ".exe" in
+  let ocamlc =
+    let (base, suffix) =
+      let s = Sys.executable_name in
+      if Filename.check_suffix s exe then
+        (Filename.chop_suffix s exe, exe)
+      else
+        (s, "") in
+    base ^ "c" ^ suffix in
+  if Sys.ocaml_version <> "%{_:version}%" then
+    (Printf.eprintf
+       "ERROR: The compiler found at %%s has version %%s,\n\
+        and this package requires %{_:version}%.\n\
+        You should use e.g. 'opam switch create %{_:name}%.%%s' \
+        instead."
+       ocamlc Sys.ocaml_version Sys.ocaml_version;
+     exit 1)
+  else
+  let ocamlc_digest = Digest.to_hex (Digest.file ocamlc) in
+  let libdir =
+    if Sys.command (ocamlc^" -where > %{_:name}%.config") = 0 then
+      let ic = open_in "%{_:name}%.config" in
+      let r = input_line ic in
+      close_in ic;
+      Sys.remove "%{_:name}%.config";
+      r
+    else
+      failwith "Bad return from 'ocamlc -where'"
+  in
+  let graphics = Filename.concat libdir "graphics.cmi" in
+  let graphics_digest =
+    if Sys.file_exists graphics then
+      Digest.to_hex (Digest.file graphics)
+    else
+      String.make 32 '0'
+  in
+  let oc = open_out "%{_:name}%.config" in
+  Printf.fprintf oc "opam-version: \"2.0\"\n\
+                     file-depends: [ [ %%S %%S ] [ %%S %%S ] ]\n\
+                     variables { path: %%S }\n"
+    ocamlc ocamlc_digest graphics graphics_digest (Filename.dirname ocamlc);
+  close_out oc

--- a/packages/ocaml/ocaml-system.4.09.0/opam
+++ b/packages/ocaml/ocaml-system.4.09.0/opam
@@ -1,0 +1,15 @@
+opam-version: "2.0"
+synopsis: "The OCaml compiler (system version, from outside of opam)"
+maintainer: "platform@lists.ocaml.org"
+depends: [
+  "ocaml" {post}
+  "base-unix" {post}
+  "base-threads" {post}
+  "base-bigarray" {post}
+]
+conflict-class: "ocaml-core-compiler"
+available: sys-ocaml-version = "4.09.0"
+flags: compiler
+build: ["ocaml" "gen_ocaml_config.ml"]
+substs: "gen_ocaml_config.ml"
+extra-files: ["gen_ocaml_config.ml.in" "md5=093e7bec1ec95f9e4c6a313d73c5d840"]

--- a/packages/ocaml/ocaml.4.09.0/opam
+++ b/packages/ocaml/ocaml.4.09.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "The OCaml compiler (virtual package)"
+description: """
+This package requires a matching implementation of OCaml,
+and polls it to initialise specific variables like `ocaml:native-dynlink`"""
+maintainer: "platform@lists.ocaml.org"
+depends: [
+  "ocaml-config"
+  "ocaml-base-compiler" {= "4.09.0"} |
+  "ocaml-variants" {>= "4.09.0" & < "4.09.1~"} |
+  "ocaml-system" {>= "4.09.0" & < "4.09.1~"}
+]
+setenv: [
+  [CAML_LD_LIBRARY_PATH = "%{_:stubsdir}%"]
+  [CAML_LD_LIBRARY_PATH += "%{lib}%/stublibs"]
+  [OCAML_TOPLEVEL_PATH = "%{toplevel}%"]
+]
+build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
+build-env: CAML_LD_LIBRARY_PATH = ""
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+authors: [
+  "Xavier Leroy"
+  "Damien Doligez"
+  "Alain Frisch"
+  "Jacques Garrigue"
+  "Didier Rémy"
+  "Jérôme Vouillon"
+]

--- a/tools/travis.sh
+++ b/tools/travis.sh
@@ -21,7 +21,7 @@ set -e
 sudo apt-get update
 opam repo remove --all default
 opam repo add xs-opam --all-switches file:///mnt
-opam switch ${OCAML_VERSION:-4.07}
+opam switch ${OCAML_VERSION:-4.08}
 opam depext -vv -y xs-toolstack
 ${INSTALL}
 EOF

--- a/tools/xs-opam-ci.env
+++ b/tools/xs-opam-ci.env
@@ -1,3 +1,3 @@
-export OCAML_VERSION="4.07"
+export OCAML_VERSION="4.08"
 export DISTRO="debian-unstable"
 export BASE_REMOTE="https://github.com/xapi-project/xs-opam.git"


### PR DESCRIPTION
* Use OCaml 4.08 by default
* Add the OCaml 4.09 compiler
* Compile with OCaml 4.09 but allow it to fail
* Compiling with OCaml 4.09 currently fails because of version constraints in upstream packages