### PR TITLE
REQ-453: add function to x509 lib to retrieve signature algorithm

### DIFF
--- a/packages/upstream/x509.0.8.1+1/files/0001-signature-algorithm.patch
+++ b/packages/upstream/x509.0.8.1+1/files/0001-signature-algorithm.patch
@@ -1,0 +1,26 @@
+diff --git a/lib/certificate.ml b/lib/certificate.ml
+index 6297dd3..5878d73 100644
+--- a/lib/certificate.ml
++++ b/lib/certificate.ml
+@@ -196,6 +196,8 @@ let validity { asn ; _ } = asn.tbs_cert.validity
+ 
+ let public_key { asn = cert ; _ } = cert.tbs_cert.pk_info
+ 
++let signature_algorithm { asn = cert ; _ } = Algorithm.to_signature_algorithm cert.signature_algo
++
+ let supports_keytype c t =
+   match public_key c, t with
+   | (`RSA _), `RSA -> true
+diff --git a/lib/x509.mli b/lib/x509.mli
+index d94f924..30bc0cb 100644
+--- a/lib/x509.mli
++++ b/lib/x509.mli
+@@ -427,6 +427,8 @@ module Certificate : sig
+ 
+   (** [extensions certificate] is the extension map of [certificate]. *)
+   val extensions : t -> Extension.t
++
++  val signature_algorithm : t -> ([> `ECDSA | `RSA ] * [> `MD5 | `SHA1 | `SHA224 | `SHA256 | `SHA384 | `SHA512 ]) option
+ end
+ 
+ (** Certificate Signing request *)

--- a/packages/upstream/x509.0.8.1+1/opam
+++ b/packages/upstream/x509.0.8.1+1/opam
@@ -30,6 +30,9 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
+patches: [
+  "0001-signature-algorithm.patch"
+]
 dev-repo: "git+https://github.com/mirleft/ocaml-x509.git"
 synopsis: "Public Key Infrastructure (RFC 5280, PKCS) purely in OCaml"
 description: """
@@ -41,6 +44,12 @@ The Public Key Cryptography Standards (PKCS) defines encoding and decoding
 (in ASN.1 DER and PEM format), which is also implemented by this library -
 namely PKCS 1, PKCS 7, PKCS 8, PKCS 9 and PKCS 10.
 """
+extra-files: [
+  [
+    "0001-signature-algorithm.patch"
+    "sha256=6ee8a3d8b758c7e4d021813665f37d492ba7e4d0ce245d972dbfcf073cd9bcc3"
+  ]
+]
 url {
   src:
     "https://github.com/mirleft/ocaml-x509/releases/download/v0.8.1/x509-v0.8.1.tbz"


### PR DESCRIPTION
This is needed to enforce SHA256 as the hash signature algorithm as the current released version does not expose the signature algorithm of a certificate in any way.

There is a will to add a function to disallow signature algorithms in x509, so we might be able to use that when the time comes, see https://github.com/mirleft/ocaml-x509/issues/123