### PR TITLE
CP-29837: use odig to build docs for all packages

### DIFF
--- a/packages/upstream-extra/b0.0.0.0/opam
+++ b/packages/upstream-extra/b0.0.0.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["The b0 programmers"]
+homepage: "https://erratique.ch/software/b0"
+doc: "https://erratique.ch/software/b0/doc"
+license: "ISC"
+dev-repo: "git+https://erratique.ch/repos/b0.git"
+bug-reports: "https://github.com/b0-system/b0/issues"
+tags: ["dev" "org:erratique" "org:b0-system" "build" ]
+depends:
+[
+  "ocaml" {>= "4.03.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "0.9.0"}
+  "cmdliner" {build &>= "1.0.2"}
+]
+build:
+[[
+  "ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{dev}%"
+]]
+
+synopsis: """Software construction care"""
+description: """\
+
+B0 is work in progress.
+
+B0 is distributed under the ISC license."""
+url {
+archive: "https://erratique.ch/software/b0/releases/b0-0.0.0.tbz"
+checksum: "f96ac96fb0182f2b97dbe9ded452544b"
+}

--- a/packages/upstream-extra/odig.0.0.4/opam
+++ b/packages/upstream-extra/odig.0.0.4/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["The odig programmers"]
+homepage: "https://erratique.ch/software/odig"
+doc: "https://erratique.ch/software/odig/doc"
+license: ["ISC" "PT-Sans-fonts" "DejaVu-fonts" ]
+dev-repo: "git+https://erratique.ch/repos/odig.git"
+bug-reports: "https://github.com/b0-system/odig/issues"
+tags: [ "org:erratique" "org:b0-system" "build" "dev" "meta" "doc" "packaging" ]
+depends: [
+  "ocaml" {>= "4.03"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "0.9.1"}
+  "cmdliner" {>= "1.0.0"}
+  "odoc" {>= "1.4.0"}
+  "b0" {<= "0.0.0"}
+]
+build: [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" ]
+
+synopsis: """Lookup documentation of installed OCaml packages"""
+description: """\
+
+odig is a command line tool to lookup documentation of installed OCaml
+packages. It shows package metadata, readmes, change logs, licenses,
+cross-referenced `odoc` API documentation and manuals.
+
+odig is distributed under the ISC license. The theme fonts have their
+own [licenses](LICENSE.md).
+"""
+url {
+archive: "https://erratique.ch/software/odig/releases/odig-0.0.4.tbz"
+checksum: "cea6608b4d0a62df5c358d771fd1a148"
+}

--- a/packages/upstream-extra/odoc.1.4.2/opam
+++ b/packages/upstream-extra/odoc.1.4.2/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+
+version: "1.4.2"
+homepage: "http://github.com/ocaml/odoc"
+doc: "https://github.com/ocaml/odoc#readme"
+bug-reports: "https://github.com/ocaml/odoc/issues"
+license: "ISC"
+
+authors: [
+  "Thomas Refis <trefis@janestreet.com>"
+  "David Sheets <sheets@alum.mit.edu>"
+  "Leo White <leo@lpw25.net>"
+]
+maintainer: "Anton Bachin <antonbachin@yahoo.com>"
+dev-repo: "git+https://github.com/ocaml/odoc.git"
+
+synopsis: "OCaml documentation generator"
+
+depends: [
+  "astring" {build}
+  "cmdliner" {build & >= "1.0.0"}
+  "cppo" {build}
+  "dune"
+  "fpath" {build}
+  "ocaml" {>= "4.02.0"}
+  "result" {build}
+  "tyxml" {build & >= "4.3.0"}
+
+  "alcotest" {dev & >= "0.8.3"}
+  "markup" {dev & >= "0.8.0"}
+  "ocamlfind" {dev}
+  "sexplib" {dev & >= "113.33.00"}
+
+  "bisect_ppx" {with-test & >= "1.3.0"}
+]
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+url {
+  src: "https://github.com/ocaml/odoc/archive/1.4.2.tar.gz"
+  checksum: "md5=d75ce63539040cd199d22203d46fc5f3"
+}

--- a/packages/upstream-extra/tyxml.4.3.0/opam
+++ b/packages/upstream-extra/tyxml.4.3.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "dev@ocsigen.org"
+homepage: "https://github.com/ocsigen/tyxml/"
+bug-reports: "https://github.com/ocsigen/tyxml/issues"
+doc: "https://ocsigen.org/tyxml/manual/"
+dev-repo: "git+https://github.com/ocsigen/tyxml.git"
+license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.02"}
+  "re" {>= "1.5.0"}
+  ("ocaml" {>= "4.07"} | "re" {>= "1.8.0"})
+  "dune"
+  "alcotest" {with-test}
+  "seq"
+  "uutf" {>= "1.0.0"}
+]
+
+synopsis:"TyXML is a library for building correct HTML and SVG documents"
+description:"""
+TyXML provides a set of convenient combinators that uses the OCaml
+type system to ensure the validity of the generated documents. TyXML
+can be used with any representation of HTML and SVG: the textual one,
+provided directly by this package, or DOM trees (`js_of_ocaml-tyxml`)
+virtual DOM (`virtual-dom`) and reactive or replicated trees
+(`eliom`). You can also create your own representation and use it to
+instantiate a new set of combinators.
+
+```ocaml
+open Tyxml
+let to_ocaml = Html.(a ~a:[a_href "ocaml.org"] [txt "OCaml!"])
+```
+"""
+authors: "The ocsigen team"
+url {
+  src:
+    "https://github.com/ocsigen/tyxml/releases/download/4.3.0/tyxml-4.3.0.tbz"
+  checksum: "md5=fd834a567f813bf447cab5f4c3a723e2"
+}


### PR DESCRIPTION
This allows the generation of html documentation for all the ocaml packages used in the toolstack, still need to think how to store/show/host the html :)