### PR TITLE
upstream-extras: add ocamlformat

### DIFF
--- a/packages/upstream-extra/fix.20200131/opam
+++ b/packages/upstream-extra/fix.20200131/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "francois.pottier@inria.fr"
+authors: [
+  "François Pottier <francois.pottier@inria.fr>"
+]
+homepage: "https://gitlab.inria.fr/fpottier/fix"
+dev-repo: "git+https://gitlab.inria.fr/fpottier/fix.git"
+bug-reports: "francois.pottier@inria.fr"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" { >= "4.03" }
+  "dune" { >= "1.3" }
+]
+synopsis: "Facilities for memoization and fixed points"
+url {
+  src:
+    "https://gitlab.inria.fr/fpottier/fix/repository/20200131/archive.tar.gz"
+  checksum: [
+    "md5=991ff031666c662eaab638d2e0f4ac1d"
+    "sha512=01c45a1d90b02ec0939e968b185a6a373ac6117e2287b9a26d3db9d71e9569d086cea50da60710fcab5c2ed9d3b4c72b76839c0651e436f1fb39c77dc7c04b5e"
+  ]
+}

--- a/packages/upstream-extra/ocamlformat.0.14.1/opam
+++ b/packages/upstream-extra/ocamlformat.0.14.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "OCamlFormat Team <ocamlformat-team@fb.com>"
+authors: "Josh Berdine <jjb@fb.com>"
+homepage: "https://github.com/ocaml-ppx/ocamlformat"
+bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
+dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
+license: "MIT"
+build: [
+  ["ocaml" "tools/gen_version.mlt" "lib/Version.ml" version] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.06"}
+  "alcotest" {with-test}
+  "base" {>= "v0.11.0"}
+  "base-unix"
+  "cmdliner"
+  "dune" {>= "2.2.0"}
+  "fix"
+  "fpath"
+  "menhir"
+  "ocaml-migrate-parsetree" {>= "1.5.0"}
+  "ocp-indent" {with-test}
+  "odoc" {>= "1.4.2"}
+  "re"
+  "stdio"
+  "uuseg" {>= "10.0.0"}
+  "uutf" {>= "1.0.1"}
+]
+synopsis: "Auto-formatter for OCaml code"
+description: "OCamlFormat is a tool to automatically format OCaml code in a uniform style."
+url {
+  src:
+    "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.14.1/ocamlformat-0.14.1.tbz"
+  checksum: [
+    "sha256=4a7d4575c202bd0413b2864be60000854feade9190f5530222679815bb21960f"
+    "sha512=95dd81fd05716d422c5b8873d0ef6665d2dcabc3e43a9cf4c8af5c4e060445d40af3910a558f5aceee63db7132296b201f241d02d920669e8be1e6a81b7a7baa"
+  ]
+}

--- a/packages/upstream-extra/uucp.13.0.0/opam
+++ b/packages/upstream-extra/uucp.13.0.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: [ "The uucp programmers" ]
+homepage: "https://erratique.ch/software/uucp"
+doc: "https://erratique.ch/software/uucp/doc/Uucp"
+dev-repo: "git+https://erratique.ch/repos/uucp.git"
+bug-reports: "https://github.com/dbuenzli/uucp/issues"
+tags: [ "unicode" "text" "character" "org:erratique" ]
+license: "ISC"
+depends: [
+ "ocaml" {>= "4.03.0"}
+ "ocamlfind" {build}
+ "ocamlbuild" {build}
+ "topkg" {build}
+ "uucd" {with-test} # dev really
+ "uunf" {with-test}
+ "uutf" {with-test}
+ ]
+depopts: [ "uunf" "uutf" "cmdliner" ]
+conflicts: [ "uutf" {< "1.0.1"}
+             "cmdliner" {< "1.0.0"} ]
+build: [[
+  "ocaml" "pkg/pkg.ml" "build"
+          "--dev-pkg" "%{pinned}%"
+          "--with-uutf" "%{uutf:installed}%"
+          "--with-uunf" "%{uunf:installed}%"
+          "--with-cmdliner" "%{cmdliner:installed}%"
+]]
+
+synopsis: """Unicode character properties for OCaml"""
+description: """\
+
+Uucp is an OCaml library providing efficient access to a selection of
+character properties of the [Unicode character database][1].
+
+Uucp is independent from any Unicode text data structure and has no
+dependencies. It is distributed under the ISC license.
+
+[1]: http://www.unicode.org/reports/tr44/
+"""
+url {
+archive: "https://erratique.ch/software/uucp/releases/uucp-13.0.0.tbz"
+checksum: "07e706249ddb2d02f0fa298804d3c739"
+}

--- a/packages/upstream-extra/uuseg.13.0.0/opam
+++ b/packages/upstream-extra/uuseg.13.0.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["The uuseg programmers"]
+homepage: "https://erratique.ch/software/uuseg"
+doc: "https://erratique.ch/software/uuseg"
+dev-repo: "git+https://erratique.ch/repos/uuseg.git"
+bug-reports: "https://github.com/dbuenzli/uuseg/issues"
+tags: [ "segmentation" "text" "unicode" "org:erratique" ]
+license: "ISC"
+depends: [ "ocaml" {>= "4.03.0"}
+           "ocamlfind" {build}
+           "ocamlbuild" {build}
+           "topkg" {build}
+           "uucp" {>= "13.0.0" & < "14.0.0"} ]
+depopts: [ "uutf"
+           "cmdliner"
+           "uutf" {with-test}
+           "cmdliner" {with-test} ]
+conflicts: [ "uutf" {< "1.0.0"} ]
+build: [[
+  "ocaml" "pkg/pkg.ml" "build"
+  "--pinned" "%{pinned}%"
+  "--with-uutf" "%{uutf:installed}%"
+  "--with-cmdliner" "%{cmdliner:installed}%" ]]
+
+synopsis: """Unicode text segmentation for OCaml"""
+description: """\
+
+Uuseg is an OCaml library for segmenting Unicode text. It implements
+the locale independent [Unicode text segmentation algorithms][1] to
+detect grapheme cluster, word and sentence boundaries and the
+[Unicode line breaking algorithm][2] to detect line break
+opportunities.
+
+The library is independent from any IO mechanism or Unicode text data
+structure and it can process text without a complete in-memory
+representation.
+
+Uuseg depends on [Uucp](http://erratique.ch/software/uucp) and
+optionally on [Uutf](http://erratique.ch/software/uutf) for support on
+OCaml UTF-X encoded strings. It is distributed under the ISC license.
+
+[1]: http://www.unicode.org/reports/tr29/
+[2]: http://www.unicode.org/reports/tr14/
+"""
+url {
+archive: "https://erratique.ch/software/uuseg/releases/uuseg-13.0.0.tbz"
+checksum: "a07a97fff61da604614ea8da0547ef6a"
+}


### PR DESCRIPTION
These changes don't need a new xs-opam release as none of these packages is used for building the toolstack.

I'm adding this so we can have a single version of ocamlformat as reference for all devs, see https://github.com/xapi-project/xcp-idl/pull/310#discussion_r415610237