### PR TITLE
add mtime

### DIFF
--- a/packages/xs-extra/xapi-database.master/opam
+++ b/packages/xs-extra/xapi-database.master/opam
@@ -24,7 +24,6 @@ depends: [
   "base-threads"
   "uuid"
   "xapi-stdext-encodings"
-  "xapi-stdext-monadic"
   "xapi-stdext-pervasives"
   "xapi-stdext-std"
   "xapi-stdext-threads"

--- a/packages/xs-extra/xapi-datamodel.master/opam
+++ b/packages/xs-extra/xapi-datamodel.master/opam
@@ -18,7 +18,6 @@ depends: [
   "xapi-consts"
   "xapi-database"
   "xapi-stdext-date"
-  "xapi-stdext-monadic"
   "xapi-stdext-std"
   "xapi-stdext-unix"
 ]

--- a/packages/xs-extra/xapi-idl.master/opam
+++ b/packages/xs-extra/xapi-idl.master/opam
@@ -19,6 +19,7 @@ depends: [
   "logs"
   "message-switch-core"
   "message-switch-unix"
+  "mtime"
   "ocaml-migrate-parsetree"
   "ppx_deriving_rpc"
   "ppx_sexp_conv"

--- a/packages/xs-extra/xapi.master/opam
+++ b/packages/xs-extra/xapi.master/opam
@@ -12,7 +12,7 @@ build: [
 depends: [
   "ocaml"
   "dune" {build & >= "1.4"}
-  "alcotest" {with-test}
+  "alcotest" # needed to generate the quicktest binary
   "angstrom"
   "base64"
   "cdrom"
@@ -57,7 +57,7 @@ depends: [
   "xapi-stdext-threads"
   "xapi-stdext-unix"
   "xapi-tapctl"
-  "xapi-test-utils"
+  "xapi-test-utils" {with-test}
   "xapi-types"
   "xapi-xenopsd"
   "xapi-idl"

--- a/packages/xs-extra/xe.master/opam
+++ b/packages/xs-extra/xe.master/opam
@@ -12,7 +12,6 @@ depends: [
   "dune" {build & >= "1.4"}
   "stunnel"
   "base-threads"
-  "fpath"
   "xapi-cli-protocol"
   "xapi-consts"
   "xapi-datamodel"

--- a/packages/xs-extra/xe.master/opam
+++ b/packages/xs-extra/xe.master/opam
@@ -12,6 +12,7 @@ depends: [
   "dune" {build & >= "1.4"}
   "stunnel"
   "base-threads"
+  "fpath"
   "xapi-cli-protocol"
   "xapi-consts"
   "xapi-datamodel"

--- a/packages/xs-extra/xen-api-client.master/opam
+++ b/packages/xs-extra/xen-api-client.master/opam
@@ -13,7 +13,7 @@ tags: [
 ]
 
 build: [
-  ["dune" "build" "-p" name]
+  ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [


### PR DESCRIPTION
xapi-idl's opam file got updated, but xs-opam didn't causing Travis to fail elsewhere.