### PR TITLE
Reintroduce depext.transition

### DIFF
--- a/packages/upstream-extra/depext.transition/opam
+++ b/packages/upstream-extra/depext.transition/opam
@@ -1,0 +1,10 @@
+opam-version: "2.0"
+maintainer: [
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+]
+depends: ["ocaml" "opam-depext"]
+available: [opam-version >= "2.0.0~beta5"]
+synopsis: "opam-depext transition package"
+description:
+  "This package has been renamed to 'opam-depext' and can safely be removed"


### PR DESCRIPTION
In 5769c37 we removed depext.transition, because
it claims to be redundant. Unfortunately that
broke travis, so we reintroduce it.