### PR TITLE
CI: ensure env vars are picked correctly on github actions and PRs trigger builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,7 @@ jobs:
   build:
     runs-on: ubuntu-20.04
     strategy:
+      fail-fast: false
       matrix:
         env: [OPAMWITHTEST: false,
               OPAMWITHTEST: true,
@@ -21,3 +22,5 @@ jobs:
         uses: actions/checkout@v2
       - name: Build the whole xs-toolstack
         run: bash tools/travis.sh
+        env: ${{ matrix.env }}
+        continue-on-error: ${{ matrix.env.RECURSIVE == '--recursive' || matrix.env.OCAML_VERSION == 4.09 }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,15 @@
 name: xs-toolstack build
 
-on: push
+on:
+  push:
+    branches:
+      - master
+      - 'release/*/lcm'
+    tags:
+      - '*'
+
+    pull_request:
+      types: [opened, synchronize, reopened]
 
 jobs:
   build:


### PR DESCRIPTION
Github changed how the environment variables from the matrix can be picked up, this corrects it.

fail-fast is disabled to be able to see all steps that fail and continue-on-error is enabled for the cases that are expected to fail. This masks the errors but not masking them makes github send notifications and emails reporting failures. There doesn't seem to be a fix yet for this behaviour.

The recursive job is aborted in travis due to timeout, with github this doesn't seem to be the case, it runs for a _long_ time. I'd consider fixing it or disabling it altogether.