### PR TITLE
CI: use valid names whe nexporting env vars

### DIFF
--- a/tools/xs-opam-ci.env
+++ b/tools/xs-opam-ci.env
@@ -1,5 +1,5 @@
 export OCAML_VERSION="4.08"
-export OCAML-VERSION="4.08.1"
+export OCAML_VERSION_FULL="4.08.1"
 export DISTRO="debian-unstable"
 export BASE_REMOTE="https://github.com/xapi-project/xs-opam.git"
 export REPOSITORY="https://github.com/xapi-project/xs-opam.git"


### PR DESCRIPTION
this was breaking travis builds in toolstack components

Signed-off-by: Pau Ruiz Safont <pau.safont@citrix.com>