### PR TITLE
maintenance: use a working container image

### DIFF
--- a/tools/xs-opam-ci.env
+++ b/tools/xs-opam-ci.env
@@ -1,6 +1,6 @@
 export OCAML_VERSION="4.08"
 export OCAML_VERSION_FULL="4.08.1"
-export DISTRO="debian-unstable"
+export DISTRO="debian-10-ocaml-4.08"
 export BASE_REMOTE="https://github.com/xapi-project/xs-opam.git"
 export REPOSITORY="https://github.com/xapi-project/xs-opam.git"
 export OPAMERRLOGLEN=10000


### PR DESCRIPTION
the previous one was unable to compile packages dependent on `threads`

This affect the CI builds of the toolstack packages.