### PR TITLE
Travis: use debian-10-ocaml-4.08

### DIFF
--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,10 +1,11 @@
-FROM        ocaml/opam2:debian-10-ocaml-4.08
+FROM ocaml/opam2:debian-10-ocaml-4.08
 MAINTAINER  Christian Lindig <christian.lindig@citrix.com>
 
 COPY . /tmp/xs-opam
 
 RUN sudo apt-get update
 RUN opam repo remove --all default \
- && opam repo add xs-opam file:///tmp/xs-opam \
+ && opam repo add xs-opam --all-switches file:///tmp/xs-opam \
+ && opam switch 4.08 \
  && opam depext -y xs-toolstack \
  && opam install xs-toolstack

--- a/tools/travis.sh
+++ b/tools/travis.sh
@@ -6,7 +6,7 @@
 
 set -e
 
-IMG='ocaml/opam2:debian-unstable'
+IMG='ocaml/opam2:debian-10-ocaml-4.08'
 
 docker pull $IMG
 if [ "${OPAMWITHTEST}" = "true" ]; then

--- a/tools/xs-opam-ci.env
+++ b/tools/xs-opam-ci.env
@@ -1,6 +1,6 @@
 export OCAML_VERSION="4.08"
 export OCAML_VERSION_FULL="4.08.1"
-export DISTRO="debian-unstable"
+export DISTRO="debian-10-ocaml-4.08"
 export BASE_REMOTE="https://github.com/xapi-project/xs-opam.git"
 export REPOSITORY="https://github.com/xapi-project/xs-opam.git"
 export OPAMERRLOGLEN=10000


### PR DESCRIPTION
We fall back to debian-10 to avoid a problem with the current
debian-unstable images.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>