### PR TITLE
ci: enable github action for stockholm branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,11 +4,11 @@ on:
   push:
     branches:
       - master
-      - 'release/*/lcm'
     tags:
-      - '*'
+      - '*.0'
   pull_request:
-    types: [opened, synchronize, reopened]
+    branches:
+      - master
   schedule:
     # run daily
     - cron: '41 3 * * *'

--- a/.github/workflows/stockholm-lcm.yml
+++ b/.github/workflows/stockholm-lcm.yml
@@ -1,0 +1,26 @@
+name: Build and test (Stockholm)
+
+on:
+  push:
+    branches:
+      - 'release/stockholm/lcm'
+    tags:
+      - '6.35.*'
+  pull_request:
+    branches:
+      - 'release/stockholm/lcm'
+  schedule:
+    # run daily
+    - cron: '23 2 * * *'
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Build the whole xs-toolstack
+        run: bash tools/travis.sh
+        env:
+          OCAML_VERSION: 4.08
+          OPAMWITHTEST: true


### PR DESCRIPTION
It's on a separate workflow file to make it easier to change the main workflow without affecting the lcm tests.