### PR TITLE
maintenance: xenctrl.dummy depends on xen libraries

### DIFF
--- a/packages/xs/xenctrl.dummy/opam
+++ b/packages/xs/xenctrl.dummy/opam
@@ -1,6 +1,5 @@
 opam-version: "2.0"
 maintainer: "jonathan.ludlam@citrix.com"
-version: "0"
 tags: [
   "org:mirage"
   "org:xapi-project"

--- a/packages/xs/xenctrl.dummy/opam
+++ b/packages/xs/xenctrl.dummy/opam
@@ -5,6 +5,16 @@ tags: [
   "org:mirage"
   "org:xapi-project"
 ]
+depexts: [
+  ["m4" "libxen-dev" "libsystemd-dev"] {os-distribution = "debian"}
+  ["libxen-dev" "uuid-dev"] {os-distribution = "ubuntu"}
+  ["xen-devel" "libuuid-devel"] {os-distribution = "centos"}
+  ["xen-devel"] {os-distribution = "fedora"}
+  ["xen-devel"] {os-distribution = "rhel"}
+  ["xen-devel"] {os-distribution = "oraclelinux"}
+  ["xen-dom0-libs-devel" "xen-libs-devel"] {os = "xenserver"}
+  ["xen-dev"] {os-distribution = "alpine"}
+]
 build: [
   ["rsync" "-avz" "/usr/lib64/ocaml/xenctrl/" "%{lib}%/xenctrl/"]
   ["rsync" "-avz" "/usr/lib64/ocaml/xenmmap/" "%{lib}%/xenmmap/"]


### PR DESCRIPTION
This should fix the travis failures for stockholm