### PR TITLE
ci: add github workflow for lcm

### DIFF
--- a/.github/workflows/lcm.yml
+++ b/.github/workflows/lcm.yml
@@ -1,0 +1,22 @@
+name: Build and test (Stockholm)
+
+on:
+  push:
+    branches:
+      - 'release/stockholm/lcm'
+    tags:
+      - '*'
+  pull_request:
+    branches:
+      - 'release/stockholm/lcm'
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Build the whole xs-toolstack
+        run: bash tools/travis.sh
+        env:
+          OCAML_VERSION: 4.08
+          OPAMWITHTEST: true


### PR DESCRIPTION
To trigger the building and testing on a particular commit the workflow file must be on its predecessor. This applies for prs, commits and tags.

Unfortunately scheduled runs for this branch have to be triggered by a workflow on the main branch this means we must manage two workflows for lcm, one here, one on the main branch.
I'll repurpose the existing lcm workflow in `master` to schedule runs for this branch.