### PR TITLE
ci: schedule jobs for stockholm lcm branch

### DIFF
--- a/.github/workflows/stockholm-lcm.yml
+++ b/.github/workflows/stockholm-lcm.yml
@@ -1,14 +1,6 @@
-name: Build and test (Stockholm)
+name: Build and test (Stockholm, scheduled)
 
 on:
-  push:
-    branches:
-      - 'release/stockholm/lcm'
-    tags:
-      - '6.35.*'
-  pull_request:
-    branches:
-      - 'release/stockholm/lcm'
   schedule:
     # run daily
     - cron: '23 2 * * *'
@@ -19,6 +11,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          ref: 'release/stockholm/lcm'
       - name: Build the whole xs-toolstack
         run: bash tools/travis.sh
         env:


### PR DESCRIPTION
Unfortunately scheduled jobs only trigger for master branch. The lcm branch can be hardcoded onto the checkout step, so it's still possible to test the branch.

I've removed the other triggers for the workflows since these will never happen.