### PR TITLE
Synchronize metadata with the latest one in the repos

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,13 +2,7 @@ name: xs-toolstack build
 
 on:
   push:
-    branches:
-      - master
-    tags:
-      - '*.0'
   pull_request:
-    branches:
-      - master
   schedule:
     # run daily
     - cron: '41 3 * * *'

--- a/packages/xs-extra/forkexec.master/opam
+++ b/packages/xs-extra/forkexec.master/opam
@@ -17,7 +17,6 @@ depends: [
   "rpclib"
   "uuidm"
   "xapi-idl"
-  "xapi-stdext-monadic"
   "xapi-stdext-pervasives"
   "xapi-stdext-unix"
 ]

--- a/packages/xs-extra/http-svr.master/opam
+++ b/packages/xs-extra/http-svr.master/opam
@@ -18,7 +18,6 @@ depends: [
   "sha"
   "stunnel"
   "xapi-stdext-date"
-  "xapi-stdext-monadic"
   "xapi-stdext-pervasives"
   "xapi-stdext-threads"
   "xapi-stdext-unix"

--- a/packages/xs-extra/rrd2csv.master/opam
+++ b/packages/xs-extra/rrd2csv.master/opam
@@ -18,8 +18,6 @@ depends: [
   "xapi-client"
   "xapi-idl"
   "xapi-rrd"
-  "xapi-stdext-monadic"
-  "xapi-stdext-pervasives"
   "xapi-stdext-std"
   "xapi-stdext-threads"
 ]

--- a/packages/xs-extra/stunnel.master/opam
+++ b/packages/xs-extra/stunnel.master/opam
@@ -12,7 +12,6 @@ depends: [
   "dune" {build}
   "forkexec"
   "safe-resources"
-  "xapi-stdext-monadic"
   "xapi-stdext-pervasives"
   "xapi-stdext-threads"
   "xapi-stdext-unix"

--- a/packages/xs-extra/xapi-forkexecd.master/opam
+++ b/packages/xs-extra/xapi-forkexecd.master/opam
@@ -17,9 +17,7 @@ depends: [
   "forkexec"
   "systemd" {>= "1.2"}
   "uuidm"
-  "xapi-stdext-monadic"
   "xapi-stdext-unix"
-  "xapi-stdext-range" {with-test}
 ]
 conflicts: [
   "fd-send-recv" {< "2.0.0"}

--- a/packages/xs-extra/xapi-idl.master/opam
+++ b/packages/xs-extra/xapi-idl.master/opam
@@ -31,7 +31,6 @@ depends: [
   "uri"
   "xapi-backtrace"
   "xapi-stdext-date"
-  "xapi-stdext-monadic"
   "xapi-stdext-pervasives"
   "xapi-stdext-threads"
   "xapi-inventory"

--- a/packages/xs-extra/xapi-networkd.master/opam
+++ b/packages/xs-extra/xapi-networkd.master/opam
@@ -20,7 +20,6 @@ depends: [
   "systemd"
   "xapi-idl"
   "xapi-inventory"
-  "xapi-stdext-monadic"
   "xapi-stdext-pervasives"
   "xapi-stdext-threads"
   "xapi-stdext-unix"

--- a/packages/xs-extra/xapi-squeezed.master/opam
+++ b/packages/xs-extra/xapi-squeezed.master/opam
@@ -12,9 +12,7 @@ depends: [
   "ocaml"
   "dune" {build}
   "uuidm"
-  "xapi-stdext-monadic"
   "xapi-stdext-pervasives"
-  "xapi-stdext-std"
   "xapi-stdext-threads"
   "xapi-stdext-unix"
   "cohttp" {>= "0.11.0"}

--- a/packages/xs-extra/xapi-tapctl.master/opam
+++ b/packages/xs-extra/xapi-tapctl.master/opam
@@ -13,7 +13,6 @@ depends: [
   "xapi-stdext-unix"
   "xapi-stdext-std"
   "xapi-stdext-threads"
-  "xapi-stdext-monadic"
   "xapi-forkexecd"
   "ppx_deriving_rpc"
   "rpclib"

--- a/packages/xs-extra/xapi-xenopsd-xc.master/opam
+++ b/packages/xs-extra/xapi-xenopsd-xc.master/opam
@@ -17,8 +17,6 @@ depends: [
   "astring"
   "base-threads"
   "base-unix"
-  "core"
-  "core_kernel"
   "ezxenstore"
   "fd-send-recv"
   "fmt"

--- a/packages/xs-extra/xapi.master/opam
+++ b/packages/xs-extra/xapi.master/opam
@@ -51,7 +51,6 @@ depends: [
   "xapi-database"
   "xapi-datamodel"
   "xapi-stdext-date"
-  "xapi-stdext-monadic"
   "xapi-stdext-pervasives"
   "xapi-stdext-std"
   "xapi-stdext-threads"

--- a/packages/xs-extra/xe.master/opam
+++ b/packages/xs-extra/xe.master/opam
@@ -10,6 +10,7 @@ build: [[ "dune" "build" "-p" name ]]
 depends: [
   "ocaml"
   "dune" {build & >= "1.4"}
+  "fpath"
   "stunnel"
   "base-threads"
   "xapi-cli-protocol"

--- a/packages/xs/xapi-test-utils.1.4.0/opam
+++ b/packages/xs/xapi-test-utils.1.4.0/opam
@@ -9,12 +9,11 @@ depends: [
   "alcotest"
   "ocaml"
   "dune" {build}
-  "xapi-stdext-monadic"
 ]
 tags: [ "org:xapi-project" ]
 synopsis: "An OCaml package with modules for easy unit testing"
 
 url {
-   src: "https://github.com/xapi-project/xapi-test-utils/archive/v1.3.0.tar.gz"
-   checksum: "md5=cc131280bf9d5abb9ca00412931c7aec"
+   src: "https://github.com/xapi-project/xapi-test-utils/archive/v1.4.0.tar.gz"
+   checksum: "sha256=a02f84d345bc8521f8e1ff65499b6c9a54e5505c583ffa11f9c95f7c0d1300e0"
 }


### PR DESCRIPTION
This fixes the xe builds and prepares the repository for the removal of stdext-monadic, only stdext packages depend on it right now.
Also relaxes the filters on the github workflows so changes can be tested in forks without PRs.