### PR TITLE
Add licenses target to report them

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ SHELL   = /bin/bash
 VERSION = $(shell git describe --abbrev=0 --tags)
 NAME 	= xs-opam-repo-$(VERSION)
 
-.PHONY: all archive clean
+.PHONY: all archive clean licenses
 
 all:
 	docker build -f tools/Dockerfile -t xenserver/xs-opam:$(VERSION) .
@@ -23,6 +23,10 @@ $(NAME).tar.gz:
 	tar czhf $@ $(NAME)
 	mv ocaml packages
 	mv upstream-extra packages
+
+# report licenses of xs-toolstack from *installed* packages
+licenses:
+	./tools/licenses.sh | column -s: -t
 
 clean:
 	rm -f  $(NAME).tar.gz

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,9 @@ $(NAME).tar.gz:
 licenses:
 	./tools/licenses.sh | column -s: -t
 
+nolicense:
+	./tools/licenses.sh | grep ': *$$' || true
+
 clean:
 	rm -f  $(NAME).tar.gz
 	rm -rf $(NAME)

--- a/tools/licenses.sh
+++ b/tools/licenses.sh
@@ -1,0 +1,14 @@
+#! /bin/bash
+# emit licenses for toolstack packages by querying them in the 
+# current opam installation. Hence, this requires the packages in this
+# repository to be installed.
+
+set -e
+
+opam list --required-by "xs-toolstack" --recursive --short |\
+xargs opam info -f name:,license: |\
+tr -d '"' |\
+awk '
+  /^name:/    { name = $2 }
+  /^license:/ { license = $2; printf("%s: %s\n",name, license); }
+'


### PR DESCRIPTION
Add Makefile target "licenses" to report the licenses of all toolstack
packages.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>