### PR TITLE
Add xs/polly.0.2.0

### DIFF
--- a/packages/xs-extra-dummy/xs-toolstack.master/opam
+++ b/packages/xs-extra-dummy/xs-toolstack.master/opam
@@ -15,6 +15,7 @@ depends: [
   "message-switch-cli"
   "nbd-tool"
   "pciutil"
+  "polly"
   "rrd2csv"
   "rrdd-plugin"
   "rrdd-plugins"

--- a/packages/xs/polly.0.2.0/opam
+++ b/packages/xs/polly.0.2.0/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+name: "polly"
+synopsis: "Bindings for the Linux epoll system call"
+description: """
+Bindings for the Linux epoll system call. The binding avoids
+  most allocation in the event loop by iterating over all file
+  descriptios that are reported as ready ."""
+maintainer: "Christian Lindig <christian.lindig@citrix.com>"
+authors: "Christian Lindig <christian.lindig@citrix.com>"
+license: "MIT"
+homepage: "https://github.com/lindig/polly"
+doc: "https://github.com/lindig/polly"
+bug-reports: "https://github.com/lindig/polly/issues"
+depends: [
+  "dune" {build}
+  "ocaml"
+  "cmdliner"
+  "base-unix"
+]
+build: ["dune" "build" "-p" name "-j" jobs "@install"]
+dev-repo: "git://github.com/lindig/polly.git"
+url {
+  src: "https://github.com/lindig/polly/archive/0.2.0.tar.gz"
+  checksum: "sha256=5513d2be1e286cb1ca67160c1903bad4e50bafcad8eeaeea9522f13675f09eec"
+}


### PR DESCRIPTION
Polly is split out of xenopsd to make it available outside.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>