### PR TITLE
maintenance: bump ocaml-pci

### DIFF
--- a/packages/xs/pci.v1.0.3/opam
+++ b/packages/xs/pci.v1.0.3/opam
@@ -35,6 +35,6 @@ depexts: [
 dev-repo: "git+https://github.com/simonjbeaumont/ocaml-pci.git"
 url {
   src:
-    "https://github.com/xapi-project/ocaml-pci/archive/v1.0.2.tar.gz"
-  checksum: "sha256=e05289445ccaaf3d6f2a32672277451c0bf8f52bc61570cc30b3bc435da131ed"
+    "https://github.com/xapi-project/ocaml-pci/archive/v1.0.3.tar.gz"
+  checksum: "sha256=fc27aa67931035d5ecfb7be7f8e1ad688f814572da0c78c2c6ee1c5889a451f1"
 }


### PR DESCRIPTION
Bump ocaml-pci to contain the following fix: 
 - CA-266936: Move pci lookups to string_opt to prevent some segfaults