### PR TITLE
travis: change container image

### DIFF
--- a/tools/travis.sh
+++ b/tools/travis.sh
@@ -7,7 +7,7 @@ set -e
 
 OCAML_VERSION=${OCAML_VERSION:-4.08}
 
-IMG="ocaml/opam2:debian-10-ocaml-$OCAML_VERSION"
+IMG="ocurrent/opam:debian-10-ocaml-$OCAML_VERSION"
 
 docker pull $IMG
 


### PR DESCRIPTION
The new one contains less compilers, cutting the size to less than half, after testing this accelerates the CI a bit.

On the second run the build for 4.08 was +2 minutes faster (19.50), 4.09 was a bit more than a minute faster (21.13), usually it takes more than 22.30: https://github.com/psafont/xs-opam/runs/1159833131 https://github.com/xapi-project/xs-opam/actions

For speeding up builds for other repos that use containers it will be a bit more difficult since the docker repository is set by upstream (ocaml-ci-scripts), so more investigation is needed.