### PR TITLE
ci: fix failure to download apt packages

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,10 @@ jobs:
       OCAML_VERSION: ${{ matrix.ocaml-version }}
 
     steps:
+      - name: Update apt cache
+        run: sudo apt-get update 
+        shell: bash
+
       - name: Checkout
         uses: actions/checkout@v2
 


### PR DESCRIPTION
The cache was out of date and the workflow tried to download versions of
package that were removed.