### PR TITLE
tools: fix travis CI for toolstack repositories

### DIFF
--- a/tools/xs-opam-ci.env
+++ b/tools/xs-opam-ci.env
@@ -1,6 +1,6 @@
 export OCAML_VERSION="4.08"
 export OCAML_VERSION_FULL="4.08.1"
-export DISTRO="debian-10-ocaml-4.08"
+export DISTRO="debian-10"
 export BASE_REMOTE="https://github.com/xapi-project/xs-opam.git"
 export REPOSITORY="https://github.com/xapi-project/xs-opam.git"
 export OPAMERRLOGLEN=10000


### PR DESCRIPTION
ocaml-ci-scripts got changed to construct the image name from DISTRO and
OCAML_VERSION, previously it only used DISTRO.

see the change in https://github.com/ocaml/ocaml-ci-scripts/commit/071d65113021b6e48a6749907a54a685397d01f1#diff-d729a609ae42944ba5fe7f089dee3bcd844bbae8ad24e01b99bc939573e4d95f