### PR TITLE
upstream: add conf-libnl3 and conf-xen

### DIFF
--- a/packages/upstream/conf-libnl3.1/opam
+++ b/packages/upstream/conf-libnl3.1/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "Reynir Björnsson <reynir@reynir.dk>"
+authors: ["Thomas Graf"]
+homepage: "https://www.infradead.org/~tgr/libnl/"
+license: "LGPL-2.1"
+build: [
+  ["pkg-config" "libnl-3.0"]
+  ["pkg-config" "libnl-route-3.0"]
+]
+depends: ["conf-pkg-config"]
+depexts: [
+  ["libnl-3-dev" "libnl-route-3-dev"] {os-family = "debian"}
+  ["libnl-3-dev" "libnl-route-3-dev"] {os-family = "ubuntu"}
+  ["libnl3" "libnl3-devel"] {os-distribution = "centos" | os-distribution = "fedora" | os-distribution = "ol"}
+  ["libnl3-devel"] {os-family = "suse"}
+  ["libnl"] {os-family = "arch"}
+  ["libnl3-dev"] {os-family = "alpine"}
+]
+available: [ os = "linux" ]
+synopsis: "Virtual package relying on a libnl system installation"
+description:
+  "This package can only install if libnl is installed on the system."
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+flags: conf

--- a/packages/upstream/conf-xen.1/files/test.c
+++ b/packages/upstream/conf-xen.1/files/test.c
@@ -1,0 +1,5 @@
+#include <xenctrl.h>
+
+int main(void) {
+  return 0;
+}

--- a/packages/upstream/conf-xen.1/opam
+++ b/packages/upstream/conf-xen.1/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "hannes@mehnert.org"
+authors: [ "hannes@mehnert.org" ]
+homepage: "https://xenproject.org/"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+license: [ "GPLv2" "LGPL3" ]
+build: [
+  ["sh" "-exc" "cc -c $CFLAGS -I/usr/local/include test.c"]
+]
+depexts: [
+  ["xen-dev"] {os-distribution = "alpine"}
+  ["libxen-dev"] {os-family = "debian"}
+  ["xen-devel"] {os-distribution = "centos"}
+  ["xen-devel"] {os-distribution = "fedora"}
+  ["xen-devel"] {os-distribution = "rhel"}
+  ["xen-devel"] {os-distribution = "ol"}
+  ["xen-devel"] {os-family = "suse"}
+  ["xen-dom0-libs-devel" "xen-libs-devel"] {os = "xenserver"}
+  ["xenstore"] {os-distribution = "arch"}
+  ["xen-tools"] {os = "freebsd"}
+]
+available: os != "macos"
+synopsis:
+  "Virtual package relying on Xen headers"
+description: """
+This package can only install if the Xen headers are installed on the system."""
+extra-files: ["test.c" "md5=456d802e49f7bb2724292347d2d167d7"]
+flags: conf


### PR DESCRIPTION
These packages ensure presence of the libnl and xen headers and free
downstream packages from having to define the correct packages for all
distributions in the depexts.

This is needed for https://github.com/xapi-project/ocaml-netlink/pull/10 and can simplify the depexts for xenopsd. (I think the conf-ssl also allows for removal of openssl and libssl depexts)