### PR TITLE
maintenance: replace depexts with conf- packages

### DIFF
--- a/packages/upstream/conf-pam.1/files/main.c
+++ b/packages/upstream/conf-pam.1/files/main.c
@@ -1,0 +1,4 @@
+#include <security/pam_appl.h>
+#include <security/pam_modules.h>
+static int missing_on_bsd = PAM_XDISPLAY;
+int main() { return 0; }

--- a/packages/upstream/conf-pam.1/opam
+++ b/packages/upstream/conf-pam.1/opam
@@ -1,0 +1,18 @@
+opam-version: "2.0"
+homepage: "https://github.com/linux-pam/linux-pam"
+author: "https://github.com/linux-pam"
+maintainer: "opensource@janestreet.com"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+
+depexts: [
+  ["libpam0g-dev"] {os-family = "debian"}
+  ["pam-devel"] {os-distribution = "centos"}
+  ["pam-devel"] {os-distribution = "fedora"}
+  ["linux-pam-dev"] {os-distribution = "alpine"}
+]
+build: [
+  ["cc" "-lpam" "main.c"]
+]
+synopsis: "Virtual package relying on a system installation of PAM"
+extra-files: ["main.c" "md5=f4bf9f8ac17a811ede3f472e58653b8e"]
+available: [ os = "linux" ]

--- a/packages/upstream/conf-python-2-7.1.1/files/test.py
+++ b/packages/upstream/conf-python-2-7.1.1/files/test.py
@@ -1,0 +1,1 @@
+print 'python-2.7 OK'

--- a/packages/upstream/conf-python-2-7.1.1/opam
+++ b/packages/upstream/conf-python-2-7.1.1/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "unixjunkie@sdf.org"
+homepage: "https://www.python.org/download/releases/2.7/"
+authors: "Python Software Foundation"
+license: "PSF"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+build: ["python2.7" "test.py"]
+depexts: [
+  ["python2.7"] {os-family = "debian"}
+  ["python27"] {os-distribution = "nixos"}
+  ["python2"] {os-distribution = "alpine"}
+  ["python2"] {os-distribution = "centos"}
+  ["python2"] {os-distribution = "fedora"}
+  ["python2"] {os-distribution = "arch"}
+  ["python"] {os-family = "suse"}
+  ["dev-lang/python:2.7"] {os-distribution = "gentoo"}
+  ["python/2.7"] {os = "openbsd"}
+  ["lang/python27"] {os = "netbsd"}
+  ["lang/python27"] {os = "freebsd"}
+  ["python27"] {os-distribution = "macports" & os = "macos"}
+  ["python"] {os-distribution = "homebrew" & os = "macos"}
+]
+synopsis: "Virtual package relying on Python-2.7 installation"
+description: """
+This package can only install if the Python-2.7 interpreter is available
+on the system."""
+extra-files: ["test.py" "md5=b2b11a2f587814ed4c08b109d9ed949f"]
+flags: conf

--- a/packages/xs-extra/stunnel.master/opam
+++ b/packages/xs-extra/stunnel.master/opam
@@ -10,8 +10,12 @@ available: [ os = "linux" ]
 depends: [
   "ocaml"
   "dune" {build}
+  "astring"
   "forkexec"
   "safe-resources"
+  "uuidm"
+  "xapi-idl"
+  "xapi-inventory"
   "xapi-stdext-pervasives"
   "xapi-stdext-threads"
   "xapi-stdext-unix"

--- a/packages/xs-extra/vhd-tool.master/opam
+++ b/packages/xs-extra/vhd-tool.master/opam
@@ -14,6 +14,7 @@ depends: [
   "ocaml"
   "dune" {build}
   "cohttp-lwt"
+  "conf-libssl"
   "cstruct" {>= "3.0.0"}
   "io-page"
   "lwt"
@@ -30,12 +31,6 @@ depends: [
   "xapi-tapctl"
   "xenstore"
   "xenstore_transport"
-]
-depexts: [
-  ["libssl-dev"] {os-distribution = "debian"}
-  ["libssl-dev"] {os-distribution = "ubuntu"}
-  ["openssl-devel"] {os-distribution = "centos"}
-  ["openssl-devel"] {os-distribution = "fedora"}
 ]
 synopsis: ".vhd file manipulation"
 url {

--- a/packages/xs-extra/xapi-storage.master/opam
+++ b/packages/xs-extra/xapi-storage.master/opam
@@ -11,6 +11,7 @@ build: [
 depends: [
   "ocaml"
   "dune" {build}
+  "conf-python-2-7"
   "ounit" {with-test}
   "alcotest" {with-test}
   "lwt" {with-test}
@@ -19,11 +20,6 @@ depends: [
   "rpclib"
   "xmlm"
   "cmdliner"
-]
-depexts: [
-  ["python"] {os-distribution = "centos"}
-  ["python"] {os-distribution = "debian"}
-  ["python"] {os-distribution = "ubuntu"}
 ]
 synopsis: "Code and documentation generator for the Xapi storage interface"
 url {

--- a/packages/xs-extra/xapi-xenopsd-xc.master/opam
+++ b/packages/xs-extra/xapi-xenopsd-xc.master/opam
@@ -30,6 +30,7 @@ depends: [
   "rpclib"
   "rresult"
   "sexplib0"
+  "uuid"
   "uuidm"
   "xapi-backtrace"
   "xapi-idl"

--- a/packages/xs-extra/xapi-xenopsd-xc.master/opam
+++ b/packages/xs-extra/xapi-xenopsd-xc.master/opam
@@ -17,6 +17,7 @@ depends: [
   "astring"
   "base-threads"
   "base-unix"
+  "conf-xen"
   "ezxenstore"
   "fd-send-recv"
   "fmt"

--- a/packages/xs-extra/xapi.master/opam
+++ b/packages/xs-extra/xapi.master/opam
@@ -16,6 +16,7 @@ depends: [
   "angstrom"
   "base64"
   "cdrom"
+  "conf-pam"
   "ctypes"
   "ctypes-foreign"
   "domain-name"
@@ -67,10 +68,10 @@ depends: [
   "zstd"
 ]
 depexts: [
-  ["hwdata" "libpci-dev" "libpam-dev" "libxxhash-dev" "libxxhash0"] {os-distribution = "debian"}
-  ["hwdata" "libpci-dev" "libpam-dev" "libxxhash-dev" "libxxhash0"] {os-distribution = "ubuntu"}
-  ["hwdata" "pciutils-devel" "pam-devel" "xxhash-devel" "xxhash-libs"] {os-distribution = "centos"}
-  ["hwdata" "pciutils-devel" "pam-devel" "xxhash-devel" "xxhash-libs"] {os-distribution = "fedora"}
+  ["hwdata" "libpci-dev" "libxxhash-dev" "libxxhash0"] {os-distribution = "debian"}
+  ["hwdata" "libpci-dev" "libxxhash-dev" "libxxhash0"] {os-distribution = "ubuntu"}
+  ["hwdata" "pciutils-devel" "xxhash-devel" "xxhash-libs"] {os-distribution = "centos"}
+  ["hwdata" "pciutils-devel" "xxhash-devel" "xxhash-libs"] {os-distribution = "fedora"}
 ]
 synopsis: "The xapi toolstack daemon which implements the XenAPI"
 description: """

--- a/packages/xs-extra/xenctrl.master/opam
+++ b/packages/xs-extra/xenctrl.master/opam
@@ -8,19 +8,10 @@ bug-reports: "https://github.com/xapi-project/xenctrl/issues"
 depends: [
   "ocaml"
   "dune" {build}
+  "conf-xen"
   "base-unix"
 ]
 build: ["dune" "build" "-p" name "-j" jobs]
-depexts: [
-  ["m4" "libxen-dev" "libsystemd-dev"] {os-distribution = "debian"}
-  ["libxen-dev" "uuid-dev"] {os-distribution = "ubuntu"}
-  ["xen-devel" "libuuid-devel"] {os-distribution = "centos"}
-  ["xen-devel"] {os-distribution = "fedora"}
-  ["xen-devel"] {os-distribution = "rhel"}
-  ["xen-devel"] {os-distribution = "oraclelinux"}
-  ["xen-dom0-libs-devel" "xen-libs-devel"] {os = "xenserver"}
-  ["xen-dev"] {os-distribution = "alpine"}
-]
 
 dev-repo: "git+https://github.com/xapi-project/xenctrl.git"
 url {

--- a/packages/xs/netlink.0.3.4/opam
+++ b/packages/xs/netlink.0.3.4/opam
@@ -10,11 +10,7 @@ depends: [
   "dune" {build}
   "ctypes"
   "ctypes-foreign"
-]
-depexts: [
-  ["libnl-3-200" "libnl-route-3-200"] {os-distribution = "debian"}
-  ["libnl-3-200" "libnl-route-3-200"] {os-distribution = "ubuntu"}
-  ["libnl3"] {os-distribution = "centos"}
+  "conf-libnl3"
 ]
 synopsis: "Bindings to the Netlink Protocol Library Suite (libnl)"
 description: """


### PR DESCRIPTION
The conf-* packages encapsulate depexts. This is convenient for us because header and binary dependencies are tough to define for all distributions and are package-specific.

Having a single dependency (like `conf-xen`) makes the dependencies easier to maintain. Right now we have depexts underspecified. Hopefully with this kind of change more dependencies can be added.