### PR TITLE
maintenance: bump stdext

### DIFF
--- a/packages/xs-extra/http-svr.master/opam
+++ b/packages/xs-extra/http-svr.master/opam
@@ -5,8 +5,8 @@ homepage: "https://xapi-project.github.io/"
 bug-reports: "https://github.com/xapi-project/xen-api-libs-transitional.git"
 dev-repo: "git+https://github.com/xapi-project/xen-api-libs-transitional.git"
 build: [
-  ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "-p" name "-j" jobs "--profile" "release" ]
+  ["dune" "runtest" "-p" name "-j" jobs "--profile" "release"] {with-test}
 ]
 available: [ os = "linux" ]
 depends: [

--- a/packages/xs-extra/xapi-libs-transitional.master/opam
+++ b/packages/xs-extra/xapi-libs-transitional.master/opam
@@ -21,7 +21,7 @@ synopsis: "Further transitional libraries required by xapi"
 description: """
 These libraries are provided for backwards compatibility only.
 No new code should use these libraries."""
-build: ["dune" "runtest" "-j" jobs] {with-test}
+build: ["dune" "runtest" "-j" jobs "--profile" "release"] {with-test}
 url {
   src:
     "https://github.com/xapi-project/xen-api-libs-transitional/archive/master.tar.gz"

--- a/packages/xs/xapi-stdext-date.4.15.0/opam
+++ b/packages/xs/xapi-stdext-date.4.15.0/opam
@@ -11,19 +11,17 @@ build:  [[ "dune" "build" "-p" name "-j" jobs ]]
 depends: [
   "ocaml"
   "dune" {build}
+  "astring"
   "base-unix"
-  "fd-send-recv" {>= "2.0.0"}
-  "xapi-stdext-pervasives"
-  "xapi-stdext-std"
+  "ptime"
 ]
-synopsis:
-  "A deprecated collection of utility functions - Unix module extensions"
+synopsis: "A deprecated collection of utility functions - Date module"
 description: """
 This library is provided for a transitionary period only.
 No new code should use this library."""
 url {
   src:
-    "https://github.com/xapi-project/stdext/archive/v4.14.0.tar.gz"
+    "https://github.com/xapi-project/stdext/archive/v4.15.0.tar.gz"
   checksum:
-    "sha256=ac1b58f3ab9760858365828212ecf265dc2cff83574096c140a6cdfafd73805d"
+    "sha256=9b334433be6692a6ffc32b774960a4516f93bbf2dac1488dde1194ab9e4c0bec"
 }

--- a/packages/xs/xapi-stdext-encodings.4.15.0/opam
+++ b/packages/xs/xapi-stdext-encodings.4.15.0/opam
@@ -18,7 +18,7 @@ This library is provided for a transitionary period only.
 No new code should use this library."""
 url {
   src:
-    "https://github.com/xapi-project/stdext/archive/v4.14.0.tar.gz"
+    "https://github.com/xapi-project/stdext/archive/v4.15.0.tar.gz"
   checksum:
-    "sha256=ac1b58f3ab9760858365828212ecf265dc2cff83574096c140a6cdfafd73805d"
+    "sha256=9b334433be6692a6ffc32b774960a4516f93bbf2dac1488dde1194ab9e4c0bec"
 }

--- a/packages/xs/xapi-stdext-pervasives.4.15.0/opam
+++ b/packages/xs/xapi-stdext-pervasives.4.15.0/opam
@@ -11,14 +11,17 @@ build:  [[ "dune" "build" "-p" name "-j" jobs ]]
 depends: [
   "ocaml"
   "dune" {build}
+  "logs"
+  "xapi-backtrace"
 ]
-synopsis: "A deprecated collection of utility functions - Zerocheck module"
+synopsis:
+  "A deprecated collection of utility functions - Pervasives extension"
 description: """
 This library is provided for a transitionary period only.
 No new code should use this library."""
 url {
   src:
-    "https://github.com/xapi-project/stdext/archive/v4.14.0.tar.gz"
+    "https://github.com/xapi-project/stdext/archive/v4.15.0.tar.gz"
   checksum:
-    "sha256=ac1b58f3ab9760858365828212ecf265dc2cff83574096c140a6cdfafd73805d"
+    "sha256=9b334433be6692a6ffc32b774960a4516f93bbf2dac1488dde1194ab9e4c0bec"
 }

--- a/packages/xs/xapi-stdext-std.4.15.0/opam
+++ b/packages/xs/xapi-stdext-std.4.15.0/opam
@@ -11,18 +11,16 @@ build:  [[ "dune" "build" "-p" name "-j" jobs ]]
 depends: [
   "ocaml"
   "dune" {build}
-  "base-threads"
-  "base-unix"
-  "xapi-stdext-pervasives"
+  "uuidm"
 ]
 synopsis:
-  "A deprecated collection of utility functions - Threads extensions and Semaphore"
+  "A deprecated collection of utility functions - Standard library extensions"
 description: """
 This library is provided for a transitionary period only.
 No new code should use this library."""
 url {
   src:
-    "https://github.com/xapi-project/stdext/archive/v4.14.0.tar.gz"
+    "https://github.com/xapi-project/stdext/archive/v4.15.0.tar.gz"
   checksum:
-    "sha256=ac1b58f3ab9760858365828212ecf265dc2cff83574096c140a6cdfafd73805d"
+    "sha256=9b334433be6692a6ffc32b774960a4516f93bbf2dac1488dde1194ab9e4c0bec"
 }

--- a/packages/xs/xapi-stdext-threads.4.15.0/opam
+++ b/packages/xs/xapi-stdext-threads.4.15.0/opam
@@ -11,17 +11,18 @@ build:  [[ "dune" "build" "-p" name "-j" jobs ]]
 depends: [
   "ocaml"
   "dune" {build}
-  "astring"
+  "base-threads"
   "base-unix"
-  "ptime"
+  "xapi-stdext-pervasives"
 ]
-synopsis: "A deprecated collection of utility functions - Date module"
+synopsis:
+  "A deprecated collection of utility functions - Threads extensions and Semaphore"
 description: """
 This library is provided for a transitionary period only.
 No new code should use this library."""
 url {
   src:
-    "https://github.com/xapi-project/stdext/archive/v4.14.0.tar.gz"
+    "https://github.com/xapi-project/stdext/archive/v4.15.0.tar.gz"
   checksum:
-    "sha256=ac1b58f3ab9760858365828212ecf265dc2cff83574096c140a6cdfafd73805d"
+    "sha256=9b334433be6692a6ffc32b774960a4516f93bbf2dac1488dde1194ab9e4c0bec"
 }

--- a/packages/xs/xapi-stdext-unix.4.15.0/opam
+++ b/packages/xs/xapi-stdext-unix.4.15.0/opam
@@ -11,16 +11,19 @@ build:  [[ "dune" "build" "-p" name "-j" jobs ]]
 depends: [
   "ocaml"
   "dune" {build}
-  "uuidm"
+  "base-unix"
+  "fd-send-recv" {>= "2.0.0"}
+  "xapi-stdext-pervasives"
+  "xapi-stdext-std"
 ]
 synopsis:
-  "A deprecated collection of utility functions - Standard library extensions"
+  "A deprecated collection of utility functions - Unix module extensions"
 description: """
 This library is provided for a transitionary period only.
 No new code should use this library."""
 url {
   src:
-    "https://github.com/xapi-project/stdext/archive/v4.14.0.tar.gz"
+    "https://github.com/xapi-project/stdext/archive/v4.15.0.tar.gz"
   checksum:
-    "sha256=ac1b58f3ab9760858365828212ecf265dc2cff83574096c140a6cdfafd73805d"
+    "sha256=9b334433be6692a6ffc32b774960a4516f93bbf2dac1488dde1194ab9e4c0bec"
 }

--- a/packages/xs/xapi-stdext-zerocheck.4.15.0/opam
+++ b/packages/xs/xapi-stdext-zerocheck.4.15.0/opam
@@ -11,17 +11,14 @@ build:  [[ "dune" "build" "-p" name "-j" jobs ]]
 depends: [
   "ocaml"
   "dune" {build}
-  "logs"
-  "xapi-backtrace"
 ]
-synopsis:
-  "A deprecated collection of utility functions - Pervasives extension"
+synopsis: "A deprecated collection of utility functions - Zerocheck module"
 description: """
 This library is provided for a transitionary period only.
 No new code should use this library."""
 url {
   src:
-    "https://github.com/xapi-project/stdext/archive/v4.14.0.tar.gz"
+    "https://github.com/xapi-project/stdext/archive/v4.15.0.tar.gz"
   checksum:
-    "sha256=ac1b58f3ab9760858365828212ecf265dc2cff83574096c140a6cdfafd73805d"
+    "sha256=9b334433be6692a6ffc32b774960a4516f93bbf2dac1488dde1194ab9e4c0bec"
 }


### PR DESCRIPTION
*  unixext: remove Fdset module and stubs
*  CP-34643: Deprecated non-idiomatic pervasivesext functions
*  maintenance: reformat pervasivesext with ocamlformat
*  CP-34643: add tests for xstringext
*  xapi-stdext-std: Do not duplicate functions from Stdlib
*  maintenance: format xstringext files with ocamlformat
*  XSI-894 handle iso8601's with no timezone