### PR TITLE
Backport! bump stdext to v4.11.2

### DIFF
--- a/packages/xs/stdext.4.11.2/opam
+++ b/packages/xs/stdext.4.11.2/opam
@@ -32,6 +32,6 @@ This library is provided for a transitionary period only.
 No new code should use this library."""
 url {
   src:
-    "https://github.com/xapi-project/stdext/archive/v4.11.1.tar.gz"
-  checksum: "sha256=9219e973963c2596a0458dd187f9bf51977625faf0794b75f8d174e27bfc50ce"
+    "https://github.com/xapi-project/stdext/archive/v4.11.2.tar.gz"
+  checksum: "sha256=0c5276e68ecbba743e76b7a609664a73dfa7cfb8d918e80084c25773528ce56e"
 }

--- a/packages/xs/xapi-stdext-date.4.11.2/opam
+++ b/packages/xs/xapi-stdext-date.4.11.2/opam
@@ -21,6 +21,6 @@ This library is provided for a transitionary period only.
 No new code should use this library."""
 url {
   src:
-    "https://github.com/xapi-project/stdext/archive/v4.11.1.tar.gz"
-  checksum: "sha256=9219e973963c2596a0458dd187f9bf51977625faf0794b75f8d174e27bfc50ce"
+    "https://github.com/xapi-project/stdext/archive/v4.11.2.tar.gz"
+  checksum: "sha256=0c5276e68ecbba743e76b7a609664a73dfa7cfb8d918e80084c25773528ce56e"
 }

--- a/packages/xs/xapi-stdext-deprecated.4.11.2/opam
+++ b/packages/xs/xapi-stdext-deprecated.4.11.2/opam
@@ -12,12 +12,12 @@ depends: [
   "ocaml"
   "dune" {build}
 ]
-synopsis: "A deprecated collection of utility functions - Encodings module"
+synopsis: "A deprecated collection of utility functions - Deprecated modules"
 description: """
 This library is provided for a transitionary period only.
 No new code should use this library."""
 url {
   src:
-    "https://github.com/xapi-project/stdext/archive/v4.11.1.tar.gz"
-  checksum: "sha256=9219e973963c2596a0458dd187f9bf51977625faf0794b75f8d174e27bfc50ce"
+    "https://github.com/xapi-project/stdext/archive/v4.11.2.tar.gz"
+  checksum: "sha256=0c5276e68ecbba743e76b7a609664a73dfa7cfb8d918e80084c25773528ce56e"
 }

--- a/packages/xs/xapi-stdext-encodings.4.11.2/opam
+++ b/packages/xs/xapi-stdext-encodings.4.11.2/opam
@@ -12,12 +12,12 @@ depends: [
   "ocaml"
   "dune" {build}
 ]
-synopsis: "A deprecated collection of utility functions - Zerocheck module"
+synopsis: "A deprecated collection of utility functions - Encodings module"
 description: """
 This library is provided for a transitionary period only.
 No new code should use this library."""
 url {
   src:
-    "https://github.com/xapi-project/stdext/archive/v4.11.1.tar.gz"
-  checksum: "sha256=9219e973963c2596a0458dd187f9bf51977625faf0794b75f8d174e27bfc50ce"
+    "https://github.com/xapi-project/stdext/archive/v4.11.2.tar.gz"
+  checksum: "sha256=0c5276e68ecbba743e76b7a609664a73dfa7cfb8d918e80084c25773528ce56e"
 }

--- a/packages/xs/xapi-stdext-monadic.4.11.2/opam
+++ b/packages/xs/xapi-stdext-monadic.4.11.2/opam
@@ -11,16 +11,14 @@ build:  [[ "dune" "build" "-p" name "-j" jobs ]]
 depends: [
   "ocaml"
   "dune" {build}
-  "uuidm"
-  "xapi-stdext-monadic"
 ]
 synopsis:
-  "A deprecated collection of utility functions - Standard library extensions"
+  "A deprecated collection of utility functions - Monadic modules (Monad, Listext, Either)"
 description: """
 This library is provided for a transitionary period only.
 No new code should use this library."""
 url {
   src:
-    "https://github.com/xapi-project/stdext/archive/v4.11.1.tar.gz"
-  checksum: "sha256=9219e973963c2596a0458dd187f9bf51977625faf0794b75f8d174e27bfc50ce"
+    "https://github.com/xapi-project/stdext/archive/v4.11.2.tar.gz"
+  checksum: "sha256=0c5276e68ecbba743e76b7a609664a73dfa7cfb8d918e80084c25773528ce56e"
 }

--- a/packages/xs/xapi-stdext-pervasives.4.11.2/opam
+++ b/packages/xs/xapi-stdext-pervasives.4.11.2/opam
@@ -11,17 +11,16 @@ build:  [[ "dune" "build" "-p" name "-j" jobs ]]
 depends: [
   "ocaml"
   "dune" {build}
-  "base-threads"
-  "base-unix"
-  "xapi-stdext-pervasives"
+  "logs"
+  "xapi-backtrace"
 ]
 synopsis:
-  "A deprecated collection of utility functions - Threads extensions and Semaphore"
+  "A deprecated collection of utility functions - Pervasives extension"
 description: """
 This library is provided for a transitionary period only.
 No new code should use this library."""
 url {
   src:
-    "https://github.com/xapi-project/stdext/archive/v4.11.1.tar.gz"
-  checksum: "sha256=9219e973963c2596a0458dd187f9bf51977625faf0794b75f8d174e27bfc50ce"
+    "https://github.com/xapi-project/stdext/archive/v4.11.2.tar.gz"
+  checksum: "sha256=0c5276e68ecbba743e76b7a609664a73dfa7cfb8d918e80084c25773528ce56e"
 }

--- a/packages/xs/xapi-stdext-range.4.11.2/opam
+++ b/packages/xs/xapi-stdext-range.4.11.2/opam
@@ -11,18 +11,13 @@ build:  [[ "dune" "build" "-p" name "-j" jobs ]]
 depends: [
   "ocaml"
   "dune" {build}
-  "base-unix"
-  "fd-send-recv" {>= "2.0.0"}
-  "xapi-stdext-pervasives"
-  "xapi-stdext-std"
 ]
-synopsis:
-  "A deprecated collection of utility functions - Unix module extensions"
+synopsis: "A deprecated collection of utility functions - Range module"
 description: """
 This library is provided for a transitionary period only.
 No new code should use this library."""
 url {
   src:
-    "https://github.com/xapi-project/stdext/archive/v4.11.1.tar.gz"
-  checksum: "sha256=9219e973963c2596a0458dd187f9bf51977625faf0794b75f8d174e27bfc50ce"
+    "https://github.com/xapi-project/stdext/archive/v4.11.2.tar.gz"
+  checksum: "sha256=0c5276e68ecbba743e76b7a609664a73dfa7cfb8d918e80084c25773528ce56e"
 }

--- a/packages/xs/xapi-stdext-std.4.11.2/opam
+++ b/packages/xs/xapi-stdext-std.4.11.2/opam
@@ -11,13 +11,16 @@ build:  [[ "dune" "build" "-p" name "-j" jobs ]]
 depends: [
   "ocaml"
   "dune" {build}
+  "uuidm"
+  "xapi-stdext-monadic"
 ]
-synopsis: "A deprecated collection of utility functions - Deprecated modules"
+synopsis:
+  "A deprecated collection of utility functions - Standard library extensions"
 description: """
 This library is provided for a transitionary period only.
 No new code should use this library."""
 url {
   src:
-    "https://github.com/xapi-project/stdext/archive/v4.11.1.tar.gz"
-  checksum: "sha256=9219e973963c2596a0458dd187f9bf51977625faf0794b75f8d174e27bfc50ce"
+    "https://github.com/xapi-project/stdext/archive/v4.11.2.tar.gz"
+  checksum: "sha256=0c5276e68ecbba743e76b7a609664a73dfa7cfb8d918e80084c25773528ce56e"
 }

--- a/packages/xs/xapi-stdext-threads.4.11.2/opam
+++ b/packages/xs/xapi-stdext-threads.4.11.2/opam
@@ -11,16 +11,17 @@ build:  [[ "dune" "build" "-p" name "-j" jobs ]]
 depends: [
   "ocaml"
   "dune" {build}
-  "logs"
-  "xapi-backtrace"
+  "base-threads"
+  "base-unix"
+  "xapi-stdext-pervasives"
 ]
 synopsis:
-  "A deprecated collection of utility functions - Pervasives extension"
+  "A deprecated collection of utility functions - Threads extensions and Semaphore"
 description: """
 This library is provided for a transitionary period only.
 No new code should use this library."""
 url {
   src:
-    "https://github.com/xapi-project/stdext/archive/v4.11.1.tar.gz"
-  checksum: "sha256=9219e973963c2596a0458dd187f9bf51977625faf0794b75f8d174e27bfc50ce"
+    "https://github.com/xapi-project/stdext/archive/v4.11.2.tar.gz"
+  checksum: "sha256=0c5276e68ecbba743e76b7a609664a73dfa7cfb8d918e80084c25773528ce56e"
 }

--- a/packages/xs/xapi-stdext-unix.4.11.2/opam
+++ b/packages/xs/xapi-stdext-unix.4.11.2/opam
@@ -11,14 +11,18 @@ build:  [[ "dune" "build" "-p" name "-j" jobs ]]
 depends: [
   "ocaml"
   "dune" {build}
+  "base-unix"
+  "fd-send-recv" {>= "2.0.0"}
+  "xapi-stdext-pervasives"
+  "xapi-stdext-std"
 ]
 synopsis:
-  "A deprecated collection of utility functions - Monadic modules (Monad, Listext, Either)"
+  "A deprecated collection of utility functions - Unix module extensions"
 description: """
 This library is provided for a transitionary period only.
 No new code should use this library."""
 url {
   src:
-    "https://github.com/xapi-project/stdext/archive/v4.11.1.tar.gz"
-  checksum: "sha256=9219e973963c2596a0458dd187f9bf51977625faf0794b75f8d174e27bfc50ce"
+    "https://github.com/xapi-project/stdext/archive/v4.11.2.tar.gz"
+  checksum: "sha256=0c5276e68ecbba743e76b7a609664a73dfa7cfb8d918e80084c25773528ce56e"
 }

--- a/packages/xs/xapi-stdext-zerocheck.4.11.2/opam
+++ b/packages/xs/xapi-stdext-zerocheck.4.11.2/opam
@@ -12,12 +12,12 @@ depends: [
   "ocaml"
   "dune" {build}
 ]
-synopsis: "A deprecated collection of utility functions - Range module"
+synopsis: "A deprecated collection of utility functions - Zerocheck module"
 description: """
 This library is provided for a transitionary period only.
 No new code should use this library."""
 url {
   src:
-    "https://github.com/xapi-project/stdext/archive/v4.11.1.tar.gz"
-  checksum: "sha256=9219e973963c2596a0458dd187f9bf51977625faf0794b75f8d174e27bfc50ce"
+    "https://github.com/xapi-project/stdext/archive/v4.11.2.tar.gz"
+  checksum: "sha256=0c5276e68ecbba743e76b7a609664a73dfa7cfb8d918e80084c25773528ce56e"
 }


### PR DESCRIPTION
Add changes in https://github.com/xapi-project/stdext/pull/60 to xs-opam

-  CA-342171 allow clients to create an iso8601 from localtime
-  maintenance: move date tests to make backport easier
-  XSI-894 handle iso8601's with no timezone
-  XSI-894 date.iso8601.to_float should assume UTC
-  date: allow timezones other than UTC for printing
-  ci: use Stockholm's xs-opam env