### PR TITLE
detect failed downloads in `opam admin cache`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ $(NAME).tar.gz:
 	mv packages/ocaml .
 	mv packages/upstream-extra .
 	env OPAMFETCH=wget opam admin cache |& tee cache.log
+	! grep ERROR cache.log
 	git archive --format=tar.gz --prefix=$(NAME)/ HEAD > $@
 	tar zxf $@
 	cd $(NAME) && ln -fs ../cache .


### PR DESCRIPTION
`opam admin cache` exits with code 0 even when it fails to download files. This results in failures in Jenkins.
Detect errors earlier by refusing to create the tarball if there were errors from `opam admin`.