### PR TITLE
CA-350872: update mirage-crypto packages

### DIFF
--- a/packages/upstream/mirage-crypto-pk.0.8.10/opam
+++ b/packages/upstream/mirage-crypto-pk.0.8.10/opam
@@ -6,38 +6,39 @@ doc:          "https://mirage.github.io/mirage-crypto/doc"
 authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
 maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
 license:      "ISC"
-synopsis:     "Simple symmetric cryptography for the modern age"
+synopsis:     "Simple public-key cryptography for the modern age"
 
 build: [ ["dune" "subst"] {pinned}
          ["dune" "build" "-p" name "-j" jobs ]
          ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
 
 depends: [
-  "conf-pkg-config" {build}
+  "conf-gmp-powm-sec" {build}
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.6"}
-  "dune-configurator" {>= "2.0.0"}
   "ounit" {with-test}
+  "randomconv" {with-test & >= "0.1.3"}
   "cstruct" {>="3.2.0"}
+  "mirage-crypto" {=version}
+  "mirage-crypto-rng" {=version}
+  "sexplib"
+  "ppx_sexp_conv"
+  "zarith" {>= "1.4"}
   "eqaf" {>= "0.7"}
-]
-depopts: [
-  "ocaml-freestanding"
+  "rresult" {>= "0.6.0"}
+  (("mirage-no-solo5" & "mirage-no-xen") | "zarith-freestanding")
 ]
 conflicts: [
   "mirage-xen" {< "6.0.0"}
-  "ocaml-freestanding" {< "0.4.1"}
 ]
 description: """
-Mirage-crypto provides symmetric ciphers (DES, AES, RC4, ChaCha20/Poly1305), and
-hashes (MD5, SHA-1, SHA-2).
+Mirage-crypto-pk provides public-key cryptography (RSA, DSA, DH).
 """
-x-commit-hash: "de521205fe4f14178f8e07ebce8063e355303d69"
 url {
   src:
-    "https://github.com/mirage/mirage-crypto/releases/download/v0.8.7/mirage-crypto-v0.8.7.tbz"
+    "https://github.com/mirage/mirage-crypto/releases/download/v0.8.10/mirage-crypto-v0.8.10.tbz"
   checksum: [
-    "sha256=bebbbe6c175aa68c763c2e5caad42de588ab0493a420bae7c03f8d390d34a8bf"
-    "sha512=e8c3f57e868361b16014666e95dbadbd22cf9295a168c61e2ab278333d79039772407468154b3a88662bb47b49b199a45b568a5d04054b445cf4e065cb448809"
+    "sha256=8a5976fe7837491d2fbd1917b77524776f70ae590e9f55cf757cc8951b5481fc"
+    "sha512=ea3a1717574d3dcc3e6ea1e930d2c0c0ffe4e69600886bff1bbaef88333f8ec7e603eb0fae4fe8dece7fc6eb5d7c300ff4e7d20ca276a336b78b401a7139ee77"
   ]
 }

--- a/packages/upstream/mirage-crypto-rng.0.8.10/opam
+++ b/packages/upstream/mirage-crypto-rng.0.8.10/opam
@@ -32,12 +32,11 @@ Mirage-crypto-rng provides a random number generator interface, and
 implementations: Fortuna, HMAC-DRBG, getrandom/getentropy based (in the unix
 sublibrary)
 """
-x-commit-hash: "de521205fe4f14178f8e07ebce8063e355303d69"
 url {
   src:
-    "https://github.com/mirage/mirage-crypto/releases/download/v0.8.7/mirage-crypto-v0.8.7.tbz"
+    "https://github.com/mirage/mirage-crypto/releases/download/v0.8.10/mirage-crypto-v0.8.10.tbz"
   checksum: [
-    "sha256=bebbbe6c175aa68c763c2e5caad42de588ab0493a420bae7c03f8d390d34a8bf"
-    "sha512=e8c3f57e868361b16014666e95dbadbd22cf9295a168c61e2ab278333d79039772407468154b3a88662bb47b49b199a45b568a5d04054b445cf4e065cb448809"
+    "sha256=8a5976fe7837491d2fbd1917b77524776f70ae590e9f55cf757cc8951b5481fc"
+    "sha512=ea3a1717574d3dcc3e6ea1e930d2c0c0ffe4e69600886bff1bbaef88333f8ec7e603eb0fae4fe8dece7fc6eb5d7c300ff4e7d20ca276a336b78b401a7139ee77"
   ]
 }

--- a/packages/upstream/mirage-crypto.0.8.10/opam
+++ b/packages/upstream/mirage-crypto.0.8.10/opam
@@ -6,40 +6,37 @@ doc:          "https://mirage.github.io/mirage-crypto/doc"
 authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
 maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
 license:      "ISC"
-synopsis:     "Simple public-key cryptography for the modern age"
+synopsis:     "Simple symmetric cryptography for the modern age"
 
 build: [ ["dune" "subst"] {pinned}
          ["dune" "build" "-p" name "-j" jobs ]
          ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
 
 depends: [
-  "conf-gmp-powm-sec" {build}
+  "conf-pkg-config" {build}
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.6"}
+  "dune-configurator" {>= "2.0.0"}
   "ounit" {with-test}
-  "randomconv" {with-test & >= "0.1.3"}
   "cstruct" {>="3.2.0"}
-  "mirage-crypto" {=version}
-  "mirage-crypto-rng" {=version}
-  "sexplib"
-  "ppx_sexp_conv"
-  "zarith" {>= "1.4"}
   "eqaf" {>= "0.7"}
-  "rresult" {>= "0.6.0"}
-  (("mirage-no-solo5" & "mirage-no-xen") | "zarith-freestanding")
+]
+depopts: [
+  "ocaml-freestanding"
 ]
 conflicts: [
   "mirage-xen" {< "6.0.0"}
+  "ocaml-freestanding" {< "0.4.1"}
 ]
 description: """
-Mirage-crypto-pk provides public-key cryptography (RSA, DSA, DH).
+Mirage-crypto provides symmetric ciphers (DES, AES, RC4, ChaCha20/Poly1305), and
+hashes (MD5, SHA-1, SHA-2).
 """
-x-commit-hash: "de521205fe4f14178f8e07ebce8063e355303d69"
 url {
   src:
-    "https://github.com/mirage/mirage-crypto/releases/download/v0.8.7/mirage-crypto-v0.8.7.tbz"
+    "https://github.com/mirage/mirage-crypto/releases/download/v0.8.10/mirage-crypto-v0.8.10.tbz"
   checksum: [
-    "sha256=bebbbe6c175aa68c763c2e5caad42de588ab0493a420bae7c03f8d390d34a8bf"
-    "sha512=e8c3f57e868361b16014666e95dbadbd22cf9295a168c61e2ab278333d79039772407468154b3a88662bb47b49b199a45b568a5d04054b445cf4e065cb448809"
+    "sha256=8a5976fe7837491d2fbd1917b77524776f70ae590e9f55cf757cc8951b5481fc"
+    "sha512=ea3a1717574d3dcc3e6ea1e930d2c0c0ffe4e69600886bff1bbaef88333f8ec7e603eb0fae4fe8dece7fc6eb5d7c300ff4e7d20ca276a336b78b401a7139ee77"
   ]
 }


### PR DESCRIPTION
Previous versions checked an invalid property of RSA key parameters.

Relevant commit in the packages: https://github.com/mirage/mirage-crypto/commit/46e6217ac33525f5b019f0f1fc229241f9b03328