### PR TITLE
upstream-extra: update merlin and ocaml-lsp-server packages

### DIFF
--- a/packages/upstream-extra/dot-merlin-reader.3.4.2/opam
+++ b/packages/upstream-extra/dot-merlin-reader.3.4.2/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+synopsis:     "Reads config files for merlin"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo: "git+https://github.com/ocaml/merlin.git"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.02.1" & < "4.12"}
+  "dune" {>= "1.8.0"}
+  "yojson" {>= "1.6.0"}
+  "ocamlfind" {>= "1.6.0"}
+  "csexp" {>= "1.2.3"}
+  "result" {>= "1.5"}
+]
+x-commit-hash: "c9761a552380838e9f530b5c47c0ea3c47c33565"
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v3.4.2/merlin-v3.4.2.tbz"
+  checksum: [
+    "sha256=e1b7b897b11119d92995c558530149fd07bd67a4aaf140f55f3c4ffb5e882a81"
+    "sha512=7c39c70fc923971c4eca9432061077941498574c0b804efc20af244c1c9ab34c9178d7eb50ab750feaac30696e7ff911a0ccd5fb86341b68485bedae472aa15f"
+  ]
+}

--- a/packages/upstream-extra/merlin.3.4.2/opam
+++ b/packages/upstream-extra/merlin.3.4.2/opam
@@ -7,15 +7,17 @@ dev-repo: "git+https://github.com/ocaml/merlin.git"
 build: [
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test & os != "macos" & ocaml:version >= "4.03"}
+  ["dune" "runtest" "-p" name "-j" "1"] {with-test & ocaml:version >= "4.03"}
 ]
 depends: [
-  "ocaml" {>= "4.02.3" & < "4.11"}
+  "ocaml" {>= "4.02.3" & < "4.12"}
   "dune" {>= "1.8.0"}
-  "ocamlfind" {>= "1.5.2"}
+  "dot-merlin-reader" {= version}
   "yojson" {>= "1.6.0"}
   "mdx" {with-test & >= "1.3.0"}
   "conf-jq" {with-test}
+  "csexp" {>= "1.2.3"}
+  "result" {>= "1.5"}
 ]
 synopsis:
   "Editor helper, provides completion, typing and source browsing in Vim and Emacs"
@@ -61,11 +63,12 @@ See https://github.com/OCamlPro/opam-user-setup
 "
   {success & !user-setup:installed}
 ]
+x-commit-hash: "c9761a552380838e9f530b5c47c0ea3c47c33565"
 url {
   src:
-    "https://github.com/ocaml/merlin/releases/download/v3.3.6/merlin-v3.3.6.tbz"
+    "https://github.com/ocaml/merlin/releases/download/v3.4.2/merlin-v3.4.2.tbz"
   checksum: [
-    "sha256=3b32d29dc225cd4a975b7345d6dadd41056312f7edfb718b175bd8294165c08c"
-    "sha512=41e5e463c3961c0b5ce77ba8e0a27bf6f426ceb5cad62593389078f30a33f0a45508d3a2c0ff1783d491044a52db33049033aee34cc7b3782a54e4c954d30a8d"
+    "sha256=e1b7b897b11119d92995c558530149fd07bd67a4aaf140f55f3c4ffb5e882a81"
+    "sha512=7c39c70fc923971c4eca9432061077941498574c0b804efc20af244c1c9ab34c9178d7eb50ab750feaac30696e7ff911a0ccd5fb86341b68485bedae472aa15f"
   ]
 }

--- a/packages/upstream-extra/ocaml-lsp-server.1.4.0/opam
+++ b/packages/upstream-extra/ocaml-lsp-server.1.4.0/opam
@@ -15,22 +15,22 @@ license: "ISC"
 homepage: "https://github.com/ocaml/ocaml-lsp"
 bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
 depends: [
+  "dune" {>= "2.5"}
   "yojson"
   "stdlib-shims"
-  "menhir"
   "ppx_yojson_conv_lib"
   "dune-build-info"
+  "dot-merlin-reader"
   "csexp" {>= "1.2.3"}
   "result" {>= "1.5"}
   "ocamlformat" {with-test}
-  "reason" {with-test}
   "ocamlfind" {>= "1.5.2"}
-  "ocaml" {>= "4.06"}
-  "dune" {>= "2.5.0"}
+  "odoc" {with-doc}
+  "ocaml" {>= "4.06" & < "4.12"}
 ]
 dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"
@@ -40,12 +40,12 @@ build: [
     "--release"
   ]
 ]
-x-commit-hash: "fee074471b2c345f7e42c6ed3482363279d4f32c"
+x-commit-hash: "92924b6e36a91ce323b7f8eddfe20def4173e6e5"
 url {
   src:
-    "https://github.com/ocaml/ocaml-lsp/releases/download/1.1.0/ocaml-lsp-server-1.1.0.tbz"
+    "https://github.com/ocaml/ocaml-lsp/releases/download/1.4.0/jsonrpc-1.4.0.tbz"
   checksum: [
-    "sha256=fa0ca1d3c5c3377f798c221381228a65e8f49fece42715d279ebe91f2f4f74c8"
-    "sha512=c00ad47478a4ddfebe3798895700d2bececa29a610c7757619f47a5b90ede921afa56efc776df3a1c4a8b2f082898423a5806d00c041dae137da1b57ee487a9b"
+    "sha256=fd138e6c4fcff32c6d15eb66cc9391b7e1183717a6d1a47c688c7f6d320a159f"
+    "sha512=567a73b3c10bb59c5a4d4e8291d1aeefdfd34438a95313fba8a485638294ca5fb8034334719631243c304d3328c27afa90dfd564fdb1e7390507a06db3a4ad03"
   ]
 }

--- a/packages/xs-extra-dummy/upstream-extra-dummy.master/opam
+++ b/packages/xs-extra-dummy/upstream-extra-dummy.master/opam
@@ -8,6 +8,7 @@ depends: [
   "merlin"
   "ocaml-system"
   "ocamlformat"
+  "ocaml-lsp-server"
   "odig"
   "travis-opam"
   "utop"

--- a/packages/xs-extra-dummy/xapi-clusterd.master/opam
+++ b/packages/xs-extra-dummy/xapi-clusterd.master/opam
@@ -3,7 +3,7 @@ depends: [
   "ocaml"
   "dune" {build & >= "1.0"}
   "alcotest" {test}
-  "alcotest-lwt" {test}
+  "alcotest-lwt"
   "angstrom"
   "astring"
   "base64" { >= "3.1.0" }


### PR DESCRIPTION
This prepares both for the newer versions of dune which do _not_ generate .merlin files.

The lsp server comes with some goodies:
- Support cancellation notifications when possible.
- Implement signature help request for functions
- Server LSP requests & notifications concurrently. Requests that require merlin are still serialized. 
- Code action to insert inferred module interface
- Filter keywords by context
- Add keyword completion
- Add go to declaration functionality to jump to a value's specification in a .mli file
