### PR TITLE
UPD-738 port kdump on top of 6.35.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ $(NAME).tar.gz:
 	mv packages/ocaml .
 	mv packages/upstream-extra .
 	env OPAMFETCH=wget opam admin cache |& tee cache.log
+	! grep ERROR cache.log
 	git archive --format=tar.gz --prefix=$(NAME)/ HEAD > $@
 	tar zxf $@
 	cd $(NAME) && ln -fs ../cache .

--- a/packages/upstream/oasis.0.4.11/opam
+++ b/packages/upstream/oasis.0.4.11/opam
@@ -56,6 +56,6 @@ like OPAM."""
 extra-files: ["oasis.install" "md5=ecc97c692bb2f70fe50124a88d705fde"]
 url {
   src:
-    "https://forge-static.ocamlcore.org/frs/download.php/1757/oasis-0.4.11.tar.gz"
+    "https://download.ocamlcore.org/oasis/oasis/0.4.11/oasis-0.4.11.tar.gz"
   checksum: "md5=98492f4657c2c5b30e3b1bc945e58419"
 }

--- a/packages/upstream/ocamlify.0.0.1/opam
+++ b/packages/upstream/ocamlify.0.0.1/opam
@@ -19,6 +19,6 @@ OCaml code."""
 extra-files: ["ocamlify.install" "md5=5ae3ee90457ab5a6051136a36885c67e"]
 url {
   src:
-    "https://forge-static.ocamlcore.org/frs/download.php/379/ocamlify-0.0.1.tar.gz"
+    "https://download.ocamlcore.org/ocamlify/ocamlify/0.0.1/ocamlify-0.0.1.tar.gz"
   checksum: "md5=bcd97ad0f7203019019997197451dbf0"
 }

--- a/packages/upstream/ocamlmod.0.0.9/opam
+++ b/packages/upstream/ocamlmod.0.0.9/opam
@@ -29,6 +29,6 @@ extra-files: [
 ]
 url {
   src:
-    "https://forge-static.ocamlcore.org/frs/download.php/1702/ocamlmod-0.0.9.tar.gz"
+    "https://download.ocamlcore.org/ocamlmod/ocamlmod/0.0.9/ocamlmod-0.0.9.tar.gz"
   checksum: "md5=b52bfbab6bb77f9736bde9c2fe81c508"
 }

--- a/packages/xs/ezxenstore.0.4.1/opam
+++ b/packages/xs/ezxenstore.0.4.1/opam
@@ -24,6 +24,6 @@ towards use within a daemon that maintains a single connection to
 xenstored."""
 url {
   src:
-    "https://github.com/xapi-project/ezxenstore/archive/v0.4.0.tar.gz"
-  checksum: "md5=a8da65998239be9014db702061958d94"
+    "https://github.com/xapi-project/ezxenstore/archive/v0.4.1.tar.gz"
+  checksum: "sha256=bb065e6335d594d02d0b6fe5274c31baa62a2bf4e74844cd91db1b981bad7c05"
 }


### PR DESCRIPTION
This PR is intended to contain kdump exclusively changes (these changes are in release/stockholm/lcm already: https://github.com/xapi-project/xs-opam/pull/549). It is intended that the branch 6.35.1-lcm will be tagged as 6.35.1.1, giving us:

6.35.1 (base) < 6.35.1.1 (kdump only) < 6.35.6 (kdump + other stockholm fixes) 