### PR TITLE
xs: update xapi-stdext packages to v4.17.0

### DIFF
--- a/packages/xs/xapi-stdext-date.4.17.0/opam
+++ b/packages/xs/xapi-stdext-date.4.17.0/opam
@@ -9,25 +9,19 @@ tags: [ "org:xapi-project" ]
 build:  [[ "dune" "build" "-p" name "-j" jobs ]]
 
 depends: [
-  "ocaml" {>= "4.08"}
-  "dune" {>= "1.11"}
+  "ocaml"
+  "dune" {build}
+  "astring"
   "base-unix"
-  "fd-send-recv" {>= "2.0.0"}
-  "xapi-stdext-pervasives" {=version}
-  "xapi-stdext-std" {=version}
+  "ptime"
 ]
-depexts: [
-  ["linux-headers"] {os-distribution = "alpine"}
-]
-available: [ os = "linux" ]
-synopsis:
-  "A deprecated collection of utility functions - Unix module extensions"
+synopsis: "A deprecated collection of utility functions - Date module"
 description: """
 This library is provided for a transitionary period only.
 No new code should use this library."""
 url {
   src:
-    "https://github.com/xapi-project/stdext/archive/v4.16.0.tar.gz"
+    "https://github.com/xapi-project/stdext/archive/v4.17.0.tar.gz"
   checksum:
-    "sha256=ed012587042f93b2cf2b1c49ecf7fb2c4ffd6bfea4af82cdfb8b9b78fd957215"
+    "sha256=8a7294ba6d3fa2d6fdee1e8e48e76cd2a8b5377c9d48d12278d577df6c3eecee"
 }

--- a/packages/xs/xapi-stdext-encodings.4.17.0/opam
+++ b/packages/xs/xapi-stdext-encodings.4.17.0/opam
@@ -18,7 +18,7 @@ This library is provided for a transitionary period only.
 No new code should use this library."""
 url {
   src:
-    "https://github.com/xapi-project/stdext/archive/v4.16.0.tar.gz"
+    "https://github.com/xapi-project/stdext/archive/v4.17.0.tar.gz"
   checksum:
-    "sha256=ed012587042f93b2cf2b1c49ecf7fb2c4ffd6bfea4af82cdfb8b9b78fd957215"
+    "sha256=8a7294ba6d3fa2d6fdee1e8e48e76cd2a8b5377c9d48d12278d577df6c3eecee"
 }

--- a/packages/xs/xapi-stdext-pervasives.4.17.0/opam
+++ b/packages/xs/xapi-stdext-pervasives.4.17.0/opam
@@ -9,20 +9,19 @@ tags: [ "org:xapi-project" ]
 build:  [[ "dune" "build" "-p" name "-j" jobs ]]
 
 depends: [
-  "ocaml"
+  "ocaml" {>= "4.08"}
   "dune" {>= "1.11"}
-  "base-threads"
-  "base-unix"
-  "xapi-stdext-pervasives" {=version}
+  "logs"
+  "xapi-backtrace"
 ]
 synopsis:
-  "A deprecated collection of utility functions - Threads extensions and Semaphore"
+  "A deprecated collection of utility functions - Pervasives extension"
 description: """
 This library is provided for a transitionary period only.
 No new code should use this library."""
 url {
   src:
-    "https://github.com/xapi-project/stdext/archive/v4.16.0.tar.gz"
+    "https://github.com/xapi-project/stdext/archive/v4.17.0.tar.gz"
   checksum:
-    "sha256=ed012587042f93b2cf2b1c49ecf7fb2c4ffd6bfea4af82cdfb8b9b78fd957215"
+    "sha256=8a7294ba6d3fa2d6fdee1e8e48e76cd2a8b5377c9d48d12278d577df6c3eecee"
 }

--- a/packages/xs/xapi-stdext-std.4.17.0/opam
+++ b/packages/xs/xapi-stdext-std.4.17.0/opam
@@ -6,19 +6,25 @@ dev-repo: "git://github.com/xapi-project/stdext.git"
 homepage: "https://xapi-project.github.io/"
 tags: [ "org:xapi-project" ]
 
-build:  [[ "dune" "build" "-p" name "-j" jobs ]]
+build:  [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
 
 depends: [
-  "ocaml"
-  "dune" {build}
+  "ocaml" {>= "4.08"}
+  "dune" {>= "1.11"}
+  "uuidm"
+  "alcotest" {with-test}
 ]
-synopsis: "A deprecated collection of utility functions - Zerocheck module"
+synopsis:
+  "A deprecated collection of utility functions - Standard library extensions"
 description: """
 This library is provided for a transitionary period only.
 No new code should use this library."""
 url {
   src:
-    "https://github.com/xapi-project/stdext/archive/v4.16.0.tar.gz"
+    "https://github.com/xapi-project/stdext/archive/v4.17.0.tar.gz"
   checksum:
-    "sha256=ed012587042f93b2cf2b1c49ecf7fb2c4ffd6bfea4af82cdfb8b9b78fd957215"
+    "sha256=8a7294ba6d3fa2d6fdee1e8e48e76cd2a8b5377c9d48d12278d577df6c3eecee"
 }

--- a/packages/xs/xapi-stdext-threads.4.17.0/opam
+++ b/packages/xs/xapi-stdext-threads.4.17.0/opam
@@ -10,18 +10,19 @@ build:  [[ "dune" "build" "-p" name "-j" jobs ]]
 
 depends: [
   "ocaml"
-  "dune" {build}
-  "astring"
+  "dune" {>= "1.11"}
+  "base-threads"
   "base-unix"
-  "ptime"
+  "xapi-stdext-pervasives" {=version}
 ]
-synopsis: "A deprecated collection of utility functions - Date module"
+synopsis:
+  "A deprecated collection of utility functions - Threads extensions and Semaphore"
 description: """
 This library is provided for a transitionary period only.
 No new code should use this library."""
 url {
   src:
-    "https://github.com/xapi-project/stdext/archive/v4.16.0.tar.gz"
+    "https://github.com/xapi-project/stdext/archive/v4.17.0.tar.gz"
   checksum:
-    "sha256=ed012587042f93b2cf2b1c49ecf7fb2c4ffd6bfea4af82cdfb8b9b78fd957215"
+    "sha256=8a7294ba6d3fa2d6fdee1e8e48e76cd2a8b5377c9d48d12278d577df6c3eecee"
 }

--- a/packages/xs/xapi-stdext-unix.4.17.0/opam
+++ b/packages/xs/xapi-stdext-unix.4.17.0/opam
@@ -6,25 +6,28 @@ dev-repo: "git://github.com/xapi-project/stdext.git"
 homepage: "https://xapi-project.github.io/"
 tags: [ "org:xapi-project" ]
 
-build:  [
-  ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
-]
+build:  [[ "dune" "build" "-p" name "-j" jobs ]]
 
 depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "1.11"}
-  "uuidm"
-  "alcotest" {with-test}
+  "base-unix"
+  "fd-send-recv" {>= "2.0.0"}
+  "xapi-stdext-pervasives" {=version}
+  "xapi-stdext-std" {=version}
 ]
+depexts: [
+  ["linux-headers"] {os-distribution = "alpine"}
+]
+available: [ os = "linux" ]
 synopsis:
-  "A deprecated collection of utility functions - Standard library extensions"
+  "A deprecated collection of utility functions - Unix module extensions"
 description: """
 This library is provided for a transitionary period only.
 No new code should use this library."""
 url {
   src:
-    "https://github.com/xapi-project/stdext/archive/v4.16.0.tar.gz"
+    "https://github.com/xapi-project/stdext/archive/v4.17.0.tar.gz"
   checksum:
-    "sha256=ed012587042f93b2cf2b1c49ecf7fb2c4ffd6bfea4af82cdfb8b9b78fd957215"
+    "sha256=8a7294ba6d3fa2d6fdee1e8e48e76cd2a8b5377c9d48d12278d577df6c3eecee"
 }

--- a/packages/xs/xapi-stdext-zerocheck.4.17.0/opam
+++ b/packages/xs/xapi-stdext-zerocheck.4.17.0/opam
@@ -9,19 +9,16 @@ tags: [ "org:xapi-project" ]
 build:  [[ "dune" "build" "-p" name "-j" jobs ]]
 
 depends: [
-  "ocaml" {>= "4.08"}
-  "dune" {>= "1.11"}
-  "logs"
-  "xapi-backtrace"
+  "ocaml"
+  "dune" {build}
 ]
-synopsis:
-  "A deprecated collection of utility functions - Pervasives extension"
+synopsis: "A deprecated collection of utility functions - Zerocheck module"
 description: """
 This library is provided for a transitionary period only.
 No new code should use this library."""
 url {
   src:
-    "https://github.com/xapi-project/stdext/archive/v4.16.0.tar.gz"
+    "https://github.com/xapi-project/stdext/archive/v4.17.0.tar.gz"
   checksum:
-    "sha256=ed012587042f93b2cf2b1c49ecf7fb2c4ffd6bfea4af82cdfb8b9b78fd957215"
+    "sha256=8a7294ba6d3fa2d6fdee1e8e48e76cd2a8b5377c9d48d12278d577df6c3eecee"
 }


### PR DESCRIPTION
This version deprecates the functions in `Listext` included from `Stdlib.List`.

I expect warnings propping up for modules in xen-api and xapi-libs-transitional, they may block the build.

They don't block the build, but there are a lot of warnings for xen-api :)