### PR TITLE
xs-extra: add lwt to xapi-idl's dependencies

### DIFF
--- a/packages/xs-extra/xapi-idl.master/opam
+++ b/packages/xs-extra/xapi-idl.master/opam
@@ -17,6 +17,7 @@ depends: [
   "cohttp"
   "fd-send-recv"
   "logs"
+  "lwt" {>= "5.0.0"}
   "message-switch-core"
   "message-switch-unix"
   "mtime"


### PR DESCRIPTION
It's used for building the binary in misc

Mirrors https://github.com/xapi-project/xcp-idl/commit/04a466eed486d5822d299da280d91f8df0d55e9e

Fixes the build issue seen in https://github.com/xapi-project/xcp-networkd/pull/191