### PR TITLE
CP-34942: Update pci and xapi-stdext packages, along with some minor updatos for upstream libraries

### DIFF
--- a/packages/upstream/lwt.5.4.1/opam
+++ b/packages/upstream/lwt.5.4.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "lwt"
-version: "5.4.0"
+version: "5.4.1"
 synopsis: "Promises and event-driven I/O"
 description: """
 A promise is a value that may become determined in the future.
@@ -51,9 +51,9 @@ build: [
 ]
 dev-repo: "git+https://github.com/ocsigen/lwt.git"
 url {
-  src: "https://github.com/ocsigen/lwt/archive/5.4.0.zip"
+  src: "https://github.com/ocsigen/lwt/archive/refs/tags/5.4.1.tar.gz"
   checksum: [
-    "md5=fc4721bdb1a01225b96e3a2debde95fa"
-    "sha512=e427f08223b77f9af696c9e6f90ff68e27e02e446910ef90d3da542e7b00bf23dd191ac77c1871288faa2289f8d28fc2f44efc3d3fe9165fe1c7a6be88ee49ff"
+    "md5=5a8d2a83ee9314781f137d147a4c62ae"
+    "sha512=b872b7abe546c431ba62fe466423d7ace8e487ebd85ea5e859f462eb4c0a6884b242d9efd4a557b6da3ae699b0b695e0a783f89a1d1147cba7d99c4ae9d2db17"
   ]
 }

--- a/packages/upstream/ppxlib.0.22.1/opam
+++ b/packages/upstream/ppxlib.0.22.1/opam
@@ -1,7 +1,7 @@
-x-commit-hash: "06a2c9bdad8c1d3361a3d9430e9bf58476b08590"
+x-commit-hash: "5830d89a7cbe3a683a5d7d9948e2d14cffffa8d3"
 opam-version: "2.0"
 name: "ppxlib"
-version: "0.22.0"
+version: "0.22.1"
 synopsis: "Standard library for ppx rewriters"
 description: """
 Ppxlib is the standard library for ppx rewriters and other programs
@@ -26,7 +26,7 @@ depends: [
   "ocaml-compiler-libs" {>= "v0.11.0"}
   "ocaml-migrate-parsetree" {>= "2.1.0"}
   "ppx_derivers" {>= "1.0"}
-  "sexplib0"
+  "sexplib0" {>= "v0.12"}
   "stdlib-shims"
   "ocamlfind" {with-test}
   "re" {with-test & >= "1.9.0"}
@@ -52,9 +52,9 @@ build: [
 dev-repo: "git+https://github.com/ocaml-ppx/ppxlib.git"
 url {
   src:
-    "https://github.com/ocaml-ppx/ppxlib/releases/download/0.22.0/ppxlib-0.22.0.tbz"
+    "https://github.com/ocaml-ppx/ppxlib/releases/download/0.22.1/ppxlib-0.22.1.tbz"
   checksum: [
-    "sha256=3eeb91e03966662284a3222e612dee7f4fa2b7637c53d9572d2a74134bb96d7a"
-    "sha512=425051dff9df53579a6edd17369d66c10f87a78daeddf1691e50997990ed643e874fcc6a30112a4dacbfd2d0097a19445354e04cd920d9522f76c51cdbc7f1db"
+    "sha256=216c802ee606c9d9f0d1e60dfe29bb69b9ae0bf12828cb148e9867abf568c5f7"
+    "sha512=3a35c3638316ee7c3acfa2e3ffbe1f7d17687e2eb1cfea6461e1be140498515d3593b5f2bf2517d5f231f214414f7cbec761403b459a7f147dcf713bf3f78106"
   ]
 }

--- a/packages/xs/pci.v1.0.4/opam
+++ b/packages/xs/pci.v1.0.4/opam
@@ -35,6 +35,6 @@ depexts: [
 dev-repo: "git+https://github.com/simonjbeaumont/ocaml-pci.git"
 url {
   src:
-    "https://github.com/xapi-project/ocaml-pci/archive/v1.0.3.tar.gz"
-  checksum: "sha256=fc27aa67931035d5ecfb7be7f8e1ad688f814572da0c78c2c6ee1c5889a451f1"
+    "https://github.com/xapi-project/ocaml-pci/archive/v1.0.4.tar.gz"
+  checksum: "sha256=9fb5e56ecc418cf54e514b70d4b6bdbff017467efbf5b02aa57c87f50477858b"
 }

--- a/packages/xs/xapi-stdext-date.4.18.0/opam
+++ b/packages/xs/xapi-stdext-date.4.18.0/opam
@@ -11,14 +11,17 @@ build:  [[ "dune" "build" "-p" name "-j" jobs ]]
 depends: [
   "ocaml"
   "dune" {build}
+  "astring"
+  "base-unix"
+  "ptime"
 ]
-synopsis: "A deprecated collection of utility functions - Zerocheck module"
+synopsis: "A deprecated collection of utility functions - Date module"
 description: """
 This library is provided for a transitionary period only.
 No new code should use this library."""
 url {
   src:
-    "https://github.com/xapi-project/stdext/archive/v4.17.0.tar.gz"
+    "https://github.com/xapi-project/stdext/archive/v4.18.0.tar.gz"
   checksum:
-    "sha256=8a7294ba6d3fa2d6fdee1e8e48e76cd2a8b5377c9d48d12278d577df6c3eecee"
+    "sha256=9f1613687958169efc7c4c58599c2348c124d96db35429b1c6d03650788d4c98"
 }

--- a/packages/xs/xapi-stdext-encodings.4.18.0/opam
+++ b/packages/xs/xapi-stdext-encodings.4.18.0/opam
@@ -6,25 +6,19 @@ dev-repo: "git://github.com/xapi-project/stdext.git"
 homepage: "https://xapi-project.github.io/"
 tags: [ "org:xapi-project" ]
 
-build:  [
-  ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
-]
+build:  [[ "dune" "build" "-p" name "-j" jobs ]]
 
 depends: [
-  "ocaml" {>= "4.08"}
-  "dune" {>= "1.11"}
-  "uuidm"
-  "alcotest" {with-test}
+  "ocaml"
+  "dune" {build}
 ]
-synopsis:
-  "A deprecated collection of utility functions - Standard library extensions"
+synopsis: "A deprecated collection of utility functions - Encodings module"
 description: """
 This library is provided for a transitionary period only.
 No new code should use this library."""
 url {
   src:
-    "https://github.com/xapi-project/stdext/archive/v4.17.0.tar.gz"
+    "https://github.com/xapi-project/stdext/archive/v4.18.0.tar.gz"
   checksum:
-    "sha256=8a7294ba6d3fa2d6fdee1e8e48e76cd2a8b5377c9d48d12278d577df6c3eecee"
+    "sha256=9f1613687958169efc7c4c58599c2348c124d96db35429b1c6d03650788d4c98"
 }

--- a/packages/xs/xapi-stdext-pervasives.4.18.0/opam
+++ b/packages/xs/xapi-stdext-pervasives.4.18.0/opam
@@ -11,23 +11,17 @@ build:  [[ "dune" "build" "-p" name "-j" jobs ]]
 depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "1.11"}
-  "base-unix"
-  "fd-send-recv" {>= "2.0.0"}
-  "xapi-stdext-pervasives" {=version}
-  "xapi-stdext-std" {=version}
+  "logs"
+  "xapi-backtrace"
 ]
-depexts: [
-  ["linux-headers"] {os-distribution = "alpine"}
-]
-available: [ os = "linux" ]
 synopsis:
-  "A deprecated collection of utility functions - Unix module extensions"
+  "A deprecated collection of utility functions - Pervasives extension"
 description: """
 This library is provided for a transitionary period only.
 No new code should use this library."""
 url {
   src:
-    "https://github.com/xapi-project/stdext/archive/v4.17.0.tar.gz"
+    "https://github.com/xapi-project/stdext/archive/v4.18.0.tar.gz"
   checksum:
-    "sha256=8a7294ba6d3fa2d6fdee1e8e48e76cd2a8b5377c9d48d12278d577df6c3eecee"
+    "sha256=9f1613687958169efc7c4c58599c2348c124d96db35429b1c6d03650788d4c98"
 }

--- a/packages/xs/xapi-stdext-std.4.18.0/opam
+++ b/packages/xs/xapi-stdext-std.4.18.0/opam
@@ -6,22 +6,25 @@ dev-repo: "git://github.com/xapi-project/stdext.git"
 homepage: "https://xapi-project.github.io/"
 tags: [ "org:xapi-project" ]
 
-build:  [[ "dune" "build" "-p" name "-j" jobs ]]
+build:  [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
 
 depends: [
-  "ocaml"
-  "dune" {build}
-  "astring"
-  "base-unix"
-  "ptime"
+  "ocaml" {>= "4.08"}
+  "dune" {>= "1.11"}
+  "uuidm"
+  "alcotest" {with-test}
 ]
-synopsis: "A deprecated collection of utility functions - Date module"
+synopsis:
+  "A deprecated collection of utility functions - Standard library extensions"
 description: """
 This library is provided for a transitionary period only.
 No new code should use this library."""
 url {
   src:
-    "https://github.com/xapi-project/stdext/archive/v4.17.0.tar.gz"
+    "https://github.com/xapi-project/stdext/archive/v4.18.0.tar.gz"
   checksum:
-    "sha256=8a7294ba6d3fa2d6fdee1e8e48e76cd2a8b5377c9d48d12278d577df6c3eecee"
+    "sha256=9f1613687958169efc7c4c58599c2348c124d96db35429b1c6d03650788d4c98"
 }

--- a/packages/xs/xapi-stdext-threads.4.18.0/opam
+++ b/packages/xs/xapi-stdext-threads.4.18.0/opam
@@ -22,7 +22,7 @@ This library is provided for a transitionary period only.
 No new code should use this library."""
 url {
   src:
-    "https://github.com/xapi-project/stdext/archive/v4.17.0.tar.gz"
+    "https://github.com/xapi-project/stdext/archive/v4.18.0.tar.gz"
   checksum:
-    "sha256=8a7294ba6d3fa2d6fdee1e8e48e76cd2a8b5377c9d48d12278d577df6c3eecee"
+    "sha256=9f1613687958169efc7c4c58599c2348c124d96db35429b1c6d03650788d4c98"
 }

--- a/packages/xs/xapi-stdext-unix.4.18.0/opam
+++ b/packages/xs/xapi-stdext-unix.4.18.0/opam
@@ -11,17 +11,23 @@ build:  [[ "dune" "build" "-p" name "-j" jobs ]]
 depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "1.11"}
-  "logs"
-  "xapi-backtrace"
+  "base-unix"
+  "fd-send-recv" {>= "2.0.0"}
+  "xapi-stdext-pervasives" {=version}
+  "xapi-stdext-std" {=version}
 ]
+depexts: [
+  ["linux-headers"] {os-distribution = "alpine"}
+]
+available: [ os = "linux" ]
 synopsis:
-  "A deprecated collection of utility functions - Pervasives extension"
+  "A deprecated collection of utility functions - Unix module extensions"
 description: """
 This library is provided for a transitionary period only.
 No new code should use this library."""
 url {
   src:
-    "https://github.com/xapi-project/stdext/archive/v4.17.0.tar.gz"
+    "https://github.com/xapi-project/stdext/archive/v4.18.0.tar.gz"
   checksum:
-    "sha256=8a7294ba6d3fa2d6fdee1e8e48e76cd2a8b5377c9d48d12278d577df6c3eecee"
+    "sha256=9f1613687958169efc7c4c58599c2348c124d96db35429b1c6d03650788d4c98"
 }

--- a/packages/xs/xapi-stdext-zerocheck.4.18.0/opam
+++ b/packages/xs/xapi-stdext-zerocheck.4.18.0/opam
@@ -12,13 +12,13 @@ depends: [
   "ocaml"
   "dune" {build}
 ]
-synopsis: "A deprecated collection of utility functions - Encodings module"
+synopsis: "A deprecated collection of utility functions - Zerocheck module"
 description: """
 This library is provided for a transitionary period only.
 No new code should use this library."""
 url {
   src:
-    "https://github.com/xapi-project/stdext/archive/v4.17.0.tar.gz"
+    "https://github.com/xapi-project/stdext/archive/v4.18.0.tar.gz"
   checksum:
-    "sha256=8a7294ba6d3fa2d6fdee1e8e48e76cd2a8b5377c9d48d12278d577df6c3eecee"
+    "sha256=9f1613687958169efc7c4c58599c2348c124d96db35429b1c6d03650788d4c98"
 }


### PR DESCRIPTION
The ocaml-pci update allows to update ctypes to 0.18, which I'd rather wait along other, more substantial changes.
The ppxlib update fixes the location reported on errors
The LWT library fixes handling of `ECONNABORTED` for `Lwt_io.establish_server*`
the stdext updates are for listext which drops the List functions.