### PR TITLE
CP-37034: add tyre: library for typed regular expressions

### DIFF
--- a/packages/upstream/tyre.0.5/opam
+++ b/packages/upstream/tyre.0.5/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer: "Gabriel Radanne <drupyog@zoho.com>"
+authors: "Gabriel Radanne <drupyog@zoho.com>"
+homepage: "https://github.com/Drup/tyre"
+doc: "https://drup.github.io/tyre/doc/0.5/tyre/Tyre/"
+bug-reports: "https://github.com/Drup/tyre/issues"
+license: "ISC"
+dev-repo: "git+https://github.com/Drup/tyre.git"
+tags: [ "regex" ]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+
+depends: [
+  "ocaml" { >= "4.03.0" }
+  "dune" {>= "1.0"}
+  "re" {>= "1.8.0"}
+  "alcotest" {with-test & >= "0.8.0"}
+  "odoc" { with-doc }
+  "result"
+  "seq"
+]
+
+synopsis: "Typed Regular Expressions"
+
+description: """
+Tyre is a set of combinators to build type-safe regular expressions,
+allowing automatic extraction and modification of matched groups.
+Tyre is bi-directional: a typed regular expressions can be used for
+parsing and unparsing. It also allows routing, by providing a list of
+regexs/routes and their handlers
+"""
+url {
+  src: "https://github.com/Drup/tyre/releases/download/0.5/tyre-0.5.tbz"
+  checksum: [
+    "sha256=7aa07fada72aa71bb9855942e0eb3ee007c339e623e145c5dd2ff80a491e9b69"
+    "sha512=ed4d48c9c00f1160540e390e676476490dfca2067da84b2b30e6bae48e34f2b7923841b9c815feefc7d62f09b31f31ba4c0d097b29e1811c9737fba5972e9cb9"
+  ]
+}

--- a/packages/xs-extra/xapi-xenopsd.master/opam
+++ b/packages/xs-extra/xapi-xenopsd.master/opam
@@ -28,6 +28,7 @@ depends: [
   "rresult"
   "sexplib"
   "sexplib0"
+  "tyre" { >= "0.5" }
   "uri"
   "uuidm"
   "uutf"


### PR DESCRIPTION
Support both parsing and unparsing.
Can be used as replacement for scanf/printf to perform validation.