### PR TITLE
maintenance: use the newly-minted xenopsd stockholm branch

### DIFF
--- a/packages/xs-extra/xapi-xenopsd-simulator.0.150.5/opam
+++ b/packages/xs-extra/xapi-xenopsd-simulator.0.150.5/opam
@@ -19,5 +19,5 @@ depends: [
 synopsis:
   "Simulation backend allowing testing of the higher-level xenops logic."
 url {
-  src: "https://github.com/xapi-project/xenopsd/archive/0.150-lcm.tar.gz"
+  src: "https://github.com/xapi-project/xenopsd/archive/0.150.5-lcm.tar.gz"
 }

--- a/packages/xs-extra/xapi-xenopsd-xc.0.150.5/opam
+++ b/packages/xs-extra/xapi-xenopsd-xc.0.150.5/opam
@@ -41,5 +41,5 @@ synopsis:
   "A xenops plugin which knows how to use xenstore, xenctrl and xenguest to manage"
 description: "VMs on a xen host."
 url {
-  src: "https://github.com/xapi-project/xenopsd/archive/0.150-lcm.tar.gz"
+  src: "https://github.com/xapi-project/xenopsd/archive/0.150.5-lcm.tar.gz"
 }

--- a/packages/xs-extra/xapi-xenopsd.0.150.5/opam
+++ b/packages/xs-extra/xapi-xenopsd.0.150.5/opam
@@ -40,5 +40,5 @@ via a simple API. The API has been tailored to suit the needs of xapi,
 which manages clusters of hosts running Xen, but it can also be used
 standalone."""
 url {
-  src: "https://github.com/xapi-project/xenopsd/archive/0.150-lcm.tar.gz"
+  src: "https://github.com/xapi-project/xenopsd/archive/0.150.5-lcm.tar.gz"
 }


### PR DESCRIPTION
This fixes the scheduled run failure: https://github.com/xapi-project/xs-opam/runs/3052779434?check_suite_focus=true#step:3:1356