### PR TITLE
Use the official cache as a mirror

### DIFF
--- a/repo
+++ b/repo
@@ -1,4 +1,4 @@
 opam-version: "2.0"
 browse: "https://github.com/xapi-project/xs-opam/tree/master/"
 upstream: "https://github.com/xapi-project/xs-opam/tree/master/"
-archive-mirrors: "cache"
+archive-mirrors: "https://opam.ocaml.org/cache"


### PR DESCRIPTION
This should minimize disruptions cause by server downtime, which is
happening quite often with inria's gitlab instance.

@mseri do you know of any downsides by doing this? I'm not worried about users not being able to configure their mirrors in this case. (https://github.com/ocaml/opam/issues/4411)