### PR TITLE
maintenance: fix build in opam 2.1.0

### DIFF
--- a/packages/upstream/conf-pkg-config.2/opam
+++ b/packages/upstream/conf-pkg-config.2/opam
@@ -3,7 +3,7 @@ name: "conf-pkg-config"
 version: "2"
 synopsis:
   "Check if pkg-config is installed and create an opam switch local pkgconfig folder"
-description: """
+description: """\
 This package can only install if the pkg-config package is installed
 on the system."""
 maintainer: "unixjunkie@sdf.org"
@@ -27,11 +27,11 @@ post-messages:
 depexts: [
   ["pkg-config"] {os-family = "debian"}
   ["pkgconf"] {os-distribution = "arch"}
-  ["pkgconfig"] {os-distribution = "fedora"}
+  ["pkgconf-pkg-config"] {os-distribution = "fedora"}
   ["pkgconfig"] {os-distribution = "centos" & os-version <= "7"}
-  ["pkgconfig"] {os-distribution = "mageia"}
+  ["pkgconf-pkg-config"] {os-distribution = "mageia"}
   ["pkgconfig"] {os-distribution = "rhel" & os-version <= "7"}
-  ["pkgconfig"] {os-distribution = "ol"}
+  ["pkgconfig"] {os-distribution = "ol" & os-version <= "7"}
   ["pkgconf"] {os-distribution = "alpine"}
   ["pkgconfig"] {os-distribution = "nixos"}
   ["devel/pkgconf"] {os = "openbsd"}
@@ -40,5 +40,6 @@ depexts: [
   ["pkgconf"] {os = "freebsd"}
   ["pkgconf-pkg-config"] {os-distribution = "rhel" & os-version >= "8"}
   ["pkgconf-pkg-config"] {os-distribution = "centos" & os-version >= "8"}
+  ["pkgconf-pkg-config"] {os-distribution = "ol" & os-version >= "8"}
   ["system:pkgconf"] {os = "win32" & os-distribution = "cygwinports"}
 ]

--- a/packages/xs/pci.v1.0.4/opam
+++ b/packages/xs/pci.v1.0.4/opam
@@ -29,7 +29,7 @@ depexts: [
   ["hwdata" "libpci-dev"] {os-family = "debian"}
   ["hwdata" "pciutils-dev"] {os-distribution = "alpine"}
   ["hwdata" "pciutils-devel"] {os-distribution = "centos"}
-  ["hwdata" "pciutil-devel"] {os-distribution = "fedora"}
+  ["hwdata" "pciutils-devel"] {os-distribution = "fedora"}
 
 ]
 dev-repo: "git+https://github.com/simonjbeaumont/ocaml-pci.git"

--- a/packages/xs/xapi-inventory.1.2.2/opam
+++ b/packages/xs/xapi-inventory.1.2.2/opam
@@ -7,14 +7,13 @@ bug-reports: "https://github.com/xapi-project/xcp-inventory/issues"
 dev-repo: "git+http://github.com/xapi-project/xcp-inventory.git"
 tags: [ "org:xapi-project" ]
 build: [
-  ["./configure" "--default_inventory=%{prefix}%/etc"]
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
-  "ocaml" {>= "4.08"}
+  "ocaml"
   "ocamlfind" {build}
-  "dune" {>= "1.4"}
+  "dune"
   "base-threads"
   "astring"
   "xapi-stdext-unix"
@@ -22,12 +21,11 @@ depends: [
   "cmdliner"
   "uuidm"
 ]
-conflicts: "xcp-inventory" {!= "transition"}
 synopsis: "Library for accessing the xapi toolstack inventory file"
 description: """
 The inventory file provides global host identify information
 needed by multiple services."""
 url {
-  src: "https://github.com/xapi-project/xcp-inventory/archive/v1.2.1.tar.gz"
-  checksum: "md5=15d24391dd45d4b318451a639c3beb46"
+  src: "https://github.com/xapi-project/xcp-inventory/archive/v1.2.2.tar.gz"
+  checksum: "sha256=49a844c3b056d8d1067520ff5417ed263dae470aef11aeea10ee1fa39fce0d2f"
 }


### PR DESCRIPTION
opam 2.1.0 uses depexts for package resolution so with broken depexts
packages cannot be installed anymore

Signed-off-by: Pau Ruiz Safont <pau.safont@citrix.com>