### PR TITLE
ci: use updated container images

### DIFF
--- a/tools/travis.sh
+++ b/tools/travis.sh
@@ -6,7 +6,7 @@
 
 set -e
 
-IMG='ocaml/opam2:debian-10-ocaml-4.08'
+IMG='ocaml/opam:debian-10-ocaml-4.08'
 
 docker pull $IMG
 if [ "${OPAMWITHTEST}" = "true" ]; then


### PR DESCRIPTION
ocaml/opam2 does not get updated anymore and have been replaced by
ocaml/opam.

Signed-off-by: Pau Ruiz Safont <pau.safont@citrix.com>