### PR TITLE
ci: use updated container images

### DIFF
--- a/tools/travis.sh
+++ b/tools/travis.sh
@@ -8,7 +8,7 @@ set -e
 OCAML_VERSION_FULL=${OCAML_VERSION_FULL:-4.08.1}
 OCAML_VERSION=${OCAML_VERSION_FULL%.*}
 
-IMG="ocaml/opam2:debian-10-ocaml-$OCAML_VERSION"
+IMG="ocaml/opam:debian-10-ocaml-$OCAML_VERSION"
 
 docker pull $IMG
 


### PR DESCRIPTION
ocaml/opam2 do not get updated anymore and have been replaced by
ocaml/opam. This fixes lcm ci.