### PR TITLE
fix: follow Stockholm branches after Yangtze split

### DIFF
--- a/packages/xs-extra/message-switch-async.1.23.1/opam
+++ b/packages/xs-extra/message-switch-async.1.23.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-name: "message-switch-lwt"
+name: "message-switch-async"
 maintainer: "xen-api@lists.xen.org"
 authors: [ "xen-api@lists.xen.org" ]
 homepage: "https://github.com/xapi-project/message-switch"
@@ -14,8 +14,8 @@ depends: [
   "ocaml"
   "dune" {build & >= "1.4"}
   "odoc" {with-doc}
-  "cohttp-lwt-unix"
-  "lwt" {>= "3.0.0"}
+  "async" {>= "v0.9.0"}
+  "cohttp-async" {>= "1.0.2"}
   "message-switch-core"
 ]
 synopsis: "A simple store-and-forward message switch"
@@ -23,5 +23,5 @@ description: """
 The switch stores messages in queues with well-known names. Clients use
 a simple HTTP protocol to enqueue and dequeue messages."""
 url {
-  src: "https://github.com/xapi-project/message-switch/archive/v1.23.0.tar.gz"
+  src: "https://github.com/xapi-project/message-switch/archive/1.23.1-lcm.tar.gz"
 }

--- a/packages/xs-extra/message-switch-cli.1.23.1/opam
+++ b/packages/xs-extra/message-switch-cli.1.23.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-name: "message-switch"
+name: "message-switch-cli"
 maintainer: "xen-api@lists.xen.org"
 authors: [ "xen-api@lists.xen.org" ]
 homepage: "https://github.com/xapi-project/message-switch"
@@ -8,32 +8,20 @@ dev-repo: "git://github.com/xapi-project/message-switch"
 tags: [ "org:xapi-project" ]
 build: [
   ["./configure" "--bindir" "%{bin}%"]
-  ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-j" jobs] {with-test}
+  [ "dune" "build" "-p" name "-j" jobs ]
 ]
 depends: [
   "ocaml"
   "dune" {build & >= "1.4"}
   "odoc" {with-doc}
   "cmdliner"
-  "cohttp-async" {with-test}
-  "cohttp-lwt-unix"
-  "io-page-unix"
-  "lwt_log"
-  "message-switch-async" {with-test}
-  "message-switch-lwt"
   "message-switch-unix"
-  "mirage-block-unix" {>= "2.4.0"}
-  "mtime" {>= "1.0.0" & < "2.0.0"}
-  "ppx_deriving_rpc" {with-test}
-  "ppx_sexp_conv"
-  "sexplib"
-  "shared-block-ring" {>= "2.3.0"}
+  "ppx_deriving_rpc"
 ]
 synopsis: "A simple store-and-forward message switch"
 description: """
 The switch stores messages in queues with well-known names. Clients use
 a simple HTTP protocol to enqueue and dequeue messages."""
 url {
-  src: "https://github.com/xapi-project/message-switch/archive/v1.23.0.tar.gz"
+  src: "https://github.com/xapi-project/message-switch/archive/1.23.1-lcm.tar.gz"
 }

--- a/packages/xs-extra/message-switch-core.1.23.1/opam
+++ b/packages/xs-extra/message-switch-core.1.23.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-name: "message-switch-cli"
+name: "message-switch-core"
 maintainer: "xen-api@lists.xen.org"
 authors: [ "xen-api@lists.xen.org" ]
 homepage: "https://github.com/xapi-project/message-switch"
@@ -14,14 +14,17 @@ depends: [
   "ocaml"
   "dune" {build & >= "1.4"}
   "odoc" {with-doc}
-  "cmdliner"
-  "message-switch-unix"
+  "astring"
+  "cohttp" {>= "0.21.1"}
   "ppx_deriving_rpc"
+  "ppx_sexp_conv"
+  "rpclib"
+  "sexplib"
 ]
 synopsis: "A simple store-and-forward message switch"
 description: """
 The switch stores messages in queues with well-known names. Clients use
 a simple HTTP protocol to enqueue and dequeue messages."""
 url {
-  src: "https://github.com/xapi-project/message-switch/archive/v1.23.0.tar.gz"
+  src: "https://github.com/xapi-project/message-switch/archive/1.23.1-lcm.tar.gz"
 }

--- a/packages/xs-extra/message-switch-lwt.1.23.1/opam
+++ b/packages/xs-extra/message-switch-lwt.1.23.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-name: "message-switch-unix"
+name: "message-switch-lwt"
 maintainer: "xen-api@lists.xen.org"
 authors: [ "xen-api@lists.xen.org" ]
 homepage: "https://github.com/xapi-project/message-switch"
@@ -14,14 +14,14 @@ depends: [
   "ocaml"
   "dune" {build & >= "1.4"}
   "odoc" {with-doc}
-  "base-threads"
+  "cohttp-lwt-unix"
+  "lwt" {>= "3.0.0"}
   "message-switch-core"
-  "ppx_deriving_rpc"
 ]
 synopsis: "A simple store-and-forward message switch"
 description: """
 The switch stores messages in queues with well-known names. Clients use
 a simple HTTP protocol to enqueue and dequeue messages."""
 url {
-  src: "https://github.com/xapi-project/message-switch/archive/v1.23.0.tar.gz"
+  src: "https://github.com/xapi-project/message-switch/archive/1.23.1-lcm.tar.gz"
 }

--- a/packages/xs-extra/message-switch-unix.1.23.1/opam
+++ b/packages/xs-extra/message-switch-unix.1.23.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-name: "message-switch-core"
+name: "message-switch-unix"
 maintainer: "xen-api@lists.xen.org"
 authors: [ "xen-api@lists.xen.org" ]
 homepage: "https://github.com/xapi-project/message-switch"
@@ -14,17 +14,14 @@ depends: [
   "ocaml"
   "dune" {build & >= "1.4"}
   "odoc" {with-doc}
-  "astring"
-  "cohttp" {>= "0.21.1"}
+  "base-threads"
+  "message-switch-core"
   "ppx_deriving_rpc"
-  "ppx_sexp_conv"
-  "rpclib"
-  "sexplib"
 ]
 synopsis: "A simple store-and-forward message switch"
 description: """
 The switch stores messages in queues with well-known names. Clients use
 a simple HTTP protocol to enqueue and dequeue messages."""
 url {
-  src: "https://github.com/xapi-project/message-switch/archive/v1.23.0.tar.gz"
+  src: "https://github.com/xapi-project/message-switch/archive/1.23.1-lcm.tar.gz"
 }

--- a/packages/xs-extra/message-switch.1.23.1/opam
+++ b/packages/xs-extra/message-switch.1.23.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-name: "message-switch-async"
+name: "message-switch"
 maintainer: "xen-api@lists.xen.org"
 authors: [ "xen-api@lists.xen.org" ]
 homepage: "https://github.com/xapi-project/message-switch"
@@ -8,20 +8,32 @@ dev-repo: "git://github.com/xapi-project/message-switch"
 tags: [ "org:xapi-project" ]
 build: [
   ["./configure" "--bindir" "%{bin}%"]
-  [ "dune" "build" "-p" name "-j" jobs ]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-j" jobs "--release"] {with-test}
 ]
 depends: [
   "ocaml"
   "dune" {build & >= "1.4"}
   "odoc" {with-doc}
-  "async" {>= "v0.9.0"}
-  "cohttp-async" {>= "1.0.2"}
-  "message-switch-core"
+  "cmdliner"
+  "cohttp-async" {with-test}
+  "cohttp-lwt-unix"
+  "io-page-unix"
+  "lwt_log"
+  "message-switch-async" {with-test}
+  "message-switch-lwt"
+  "message-switch-unix"
+  "mirage-block-unix" {>= "2.4.0"}
+  "mtime" {>= "1.0.0" & < "2.0.0"}
+  "ppx_deriving_rpc" {with-test}
+  "ppx_sexp_conv"
+  "sexplib"
+  "shared-block-ring" {>= "2.3.0"}
 ]
 synopsis: "A simple store-and-forward message switch"
 description: """
 The switch stores messages in queues with well-known names. Clients use
 a simple HTTP protocol to enqueue and dequeue messages."""
 url {
-  src: "https://github.com/xapi-project/message-switch/archive/v1.23.0.tar.gz"
+  src: "https://github.com/xapi-project/message-switch/archive/1.23.1-lcm.tar.gz"
 }

--- a/packages/xs-extra/xapi-cli-protocol.1.249.10/opam
+++ b/packages/xs-extra/xapi-cli-protocol.1.249.10/opam
@@ -10,27 +10,16 @@ build: [[ "dune" "build" "-p" name ]]
 depends: [
   "ocaml"
   "dune" {build & >= "1.4"}
-  "astring"
-  "http-svr"
-  "ocaml-migrate-parsetree"
-  "ppx_deriving_rpc"
-  "rpclib"
-  "sexpr"
   "base-threads"
-  "uuid"
-  "uuidm"
   "xapi-consts"
   "xapi-datamodel"
-  "xapi-stdext-date"
-  "xapi-stdext-pervasives"
   "xapi-stdext-std"
   "xapi-stdext-unix"
-  "xapi-idl"
 ]
 synopsis: "The xapi toolstack daemon which implements the XenAPI"
 description: """
 This daemon exposes the XenAPI and is used by clients such as 'xe'
 and 'XenCenter' to manage clusters of Xen-enabled hosts."""
 url {
-  src: "https://github.com/xapi-project/xen-api/archive/1.249-lcm.tar.gz"
+  src: "https://github.com/xapi-project/xen-api/archive/1.249.10-lcm.tar.gz"
 }

--- a/packages/xs-extra/xapi-client.1.249.10/opam
+++ b/packages/xs-extra/xapi-client.1.249.10/opam
@@ -10,21 +10,22 @@ build: [[ "dune" "build" "-p" name ]]
 depends: [
   "ocaml"
   "dune" {build & >= "1.4"}
-  "mustache"
-  "ocaml-migrate-parsetree"
-  "ppx_deriving_rpc"
-  "rpclib"
+  "mtime"
+  "sexpr"
   "base-threads"
+  "uuid"
   "xapi-consts"
-  "xapi-database"
+  "xapi-datamodel"
   "xapi-stdext-date"
+  "xapi-stdext-pervasives"
   "xapi-stdext-std"
   "xapi-stdext-unix"
+  "xapi-types"
 ]
 synopsis: "The xapi toolstack daemon which implements the XenAPI"
 description: """
 This daemon exposes the XenAPI and is used by clients such as 'xe'
 and 'XenCenter' to manage clusters of Xen-enabled hosts."""
 url {
-  src: "https://github.com/xapi-project/xen-api/archive/1.249-lcm.tar.gz"
+  src: "https://github.com/xapi-project/xen-api/archive/1.249.10-lcm.tar.gz"
 }

--- a/packages/xs-extra/xapi-consts.1.249.10/opam
+++ b/packages/xs-extra/xapi-consts.1.249.10/opam
@@ -5,35 +5,17 @@ homepage: "https://github.com/xapi-project/xen-api"
 bug-reports: "https://github.com/xapi-project/xen-api/issues"
 dev-repo: "git+https://github.com/xapi-project/xen-api.git"
 build-env: [[ XAPI_VERSION = "v0.0.0" ]]
-build: [
-  ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name] {with-test}
-]
+build: [[ "dune" "build" "-p" name ]]
 
 depends: [
   "ocaml"
   "dune" {build & >= "1.4"}
-  "alcotest" {with-test}
-  "gzip"
-  "http-svr"
-  "ocaml-migrate-parsetree"
-  "ppx_deriving_rpc"
-  "ppx_sexp_conv"
-  "rpclib"
-  "sexpr"
-  "base-threads"
-  "uuid"
-  "xapi-stdext-encodings"
-  "xapi-stdext-pervasives"
-  "xapi-stdext-std"
-  "xapi-stdext-threads"
-  "xapi-stdext-unix"
-  "xapi-idl"
+  "xapi-inventory"
 ]
 synopsis: "The xapi toolstack daemon which implements the XenAPI"
 description: """
 This daemon exposes the XenAPI and is used by clients such as 'xe'
 and 'XenCenter' to manage clusters of Xen-enabled hosts."""
 url {
-  src: "https://github.com/xapi-project/xen-api/archive/1.249-lcm.tar.gz"
+  src: "https://github.com/xapi-project/xen-api/archive/1.249.10-lcm.tar.gz"
 }

--- a/packages/xs-extra/xapi-database.249.10/opam
+++ b/packages/xs-extra/xapi-database.249.10/opam
@@ -5,27 +5,35 @@ homepage: "https://github.com/xapi-project/xen-api"
 bug-reports: "https://github.com/xapi-project/xen-api/issues"
 dev-repo: "git+https://github.com/xapi-project/xen-api.git"
 build-env: [[ XAPI_VERSION = "v0.0.0" ]]
-build: [[ "dune" "build" "-p" name ]]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
 
 depends: [
   "ocaml"
   "dune" {build & >= "1.4"}
-  "mtime"
+  "alcotest" {with-test}
+  "gzip"
+  "http-svr"
+  "ocaml-migrate-parsetree"
+  "ppx_deriving_rpc"
+  "ppx_sexp_conv"
+  "rpclib"
   "sexpr"
   "base-threads"
   "uuid"
-  "xapi-consts"
-  "xapi-datamodel"
-  "xapi-stdext-date"
+  "xapi-stdext-encodings"
   "xapi-stdext-pervasives"
   "xapi-stdext-std"
+  "xapi-stdext-threads"
   "xapi-stdext-unix"
-  "xapi-types"
+  "xapi-idl"
 ]
 synopsis: "The xapi toolstack daemon which implements the XenAPI"
 description: """
 This daemon exposes the XenAPI and is used by clients such as 'xe'
 and 'XenCenter' to manage clusters of Xen-enabled hosts."""
 url {
-  src: "https://github.com/xapi-project/xen-api/archive/1.249-lcm.tar.gz"
+  src: "https://github.com/xapi-project/xen-api/archive/1.249.10-lcm.tar.gz"
 }

--- a/packages/xs-extra/xapi-datamodel.249.10/opam
+++ b/packages/xs-extra/xapi-datamodel.249.10/opam
@@ -10,9 +10,14 @@ build: [[ "dune" "build" "-p" name ]]
 depends: [
   "ocaml"
   "dune" {build & >= "1.4"}
+  "mustache"
+  "ocaml-migrate-parsetree"
+  "ppx_deriving_rpc"
+  "rpclib"
   "base-threads"
   "xapi-consts"
-  "xapi-datamodel"
+  "xapi-database"
+  "xapi-stdext-date"
   "xapi-stdext-std"
   "xapi-stdext-unix"
 ]
@@ -21,5 +26,5 @@ description: """
 This daemon exposes the XenAPI and is used by clients such as 'xe'
 and 'XenCenter' to manage clusters of Xen-enabled hosts."""
 url {
-  src: "https://github.com/xapi-project/xen-api/archive/1.249-lcm.tar.gz"
+  src: "https://github.com/xapi-project/xen-api/archive/1.249.10-lcm.tar.gz"
 }

--- a/packages/xs-extra/xapi-idl.1.96.1/opam
+++ b/packages/xs-extra/xapi-idl.1.96.1/opam
@@ -46,5 +46,5 @@ The xapi toolstack is a set of communicating services including
   - rrdd: manages datasources and records history
 plus storage 'plugins'"""
 url {
-  src: "https://github.com/xapi-project/xcp-idl/archive/1.96-lcm.tar.gz"
+  src: "https://github.com/xapi-project/xcp-idl/archive/1.96.1-lcm.tar.gz"
 }

--- a/packages/xs-extra/xapi-types.1.249.10/opam
+++ b/packages/xs-extra/xapi-types.1.249.10/opam
@@ -10,12 +10,27 @@ build: [[ "dune" "build" "-p" name ]]
 depends: [
   "ocaml"
   "dune" {build & >= "1.4"}
-  "xapi-inventory"
+  "astring"
+  "http-svr"
+  "ocaml-migrate-parsetree"
+  "ppx_deriving_rpc"
+  "rpclib"
+  "sexpr"
+  "base-threads"
+  "uuid"
+  "uuidm"
+  "xapi-consts"
+  "xapi-datamodel"
+  "xapi-stdext-date"
+  "xapi-stdext-pervasives"
+  "xapi-stdext-std"
+  "xapi-stdext-unix"
+  "xapi-idl"
 ]
 synopsis: "The xapi toolstack daemon which implements the XenAPI"
 description: """
 This daemon exposes the XenAPI and is used by clients such as 'xe'
 and 'XenCenter' to manage clusters of Xen-enabled hosts."""
 url {
-  src: "https://github.com/xapi-project/xen-api/archive/1.249-lcm.tar.gz"
+  src: "https://github.com/xapi-project/xen-api/archive/1.249.10-lcm.tar.gz"
 }

--- a/packages/xs-extra/xapi.1.249.10/opam
+++ b/packages/xs-extra/xapi.1.249.10/opam
@@ -76,5 +76,5 @@ description: """
 This daemon exposes the XenAPI and is used by clients such as 'xe'
 and 'XenCenter' to manage clusters of Xen-enabled hosts."""
 url {
-  src: "https://github.com/xapi-project/xen-api/archive/1.249-lcm.tar.gz"
+  src: "https://github.com/xapi-project/xen-api/archive/1.249.10-lcm.tar.gz"
 }

--- a/packages/xs-extra/xe.1.249.10/opam
+++ b/packages/xs-extra/xe.1.249.10/opam
@@ -25,5 +25,5 @@ description: """
 This daemon exposes the XenAPI and is used by clients such as 'xe'
 and 'XenCenter' to manage clusters of Xen-enabled hosts."""
 url {
-  src: "https://github.com/xapi-project/xen-api/archive/1.249-lcm.tar.gz"
+  src: "https://github.com/xapi-project/xen-api/archive/1.249.10-lcm.tar.gz"
 }


### PR DESCRIPTION
This affects message-switch, xapi-idl and xapi, other repositories were
already branched or are still not branched.

Signed-off-by: Pau Ruiz Safont <pau.safont@citrix.com>