### PR TITLE
specsavers: move remaining independent daemons to xen-api

### DIFF
--- a/packages/xs-extra/http-svr.master/opam
+++ b/packages/xs-extra/http-svr.master/opam
@@ -5,8 +5,8 @@ homepage: "https://xapi-project.github.io/"
 bug-reports: "https://github.com/xapi-project/xen-api.git"
 dev-repo: "git+https://github.com/xapi-project/xen-api.git"
 build: [
-  ["dune" "build" "-p" name "-j" jobs "--profile" "release" ]
-  ["dune" "runtest" "-p" name "-j" jobs "--profile" "release"] {with-test}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 available: [ os = "linux" ]
 depends: [

--- a/packages/xs-extra/varstored-guard.master/opam
+++ b/packages/xs-extra/varstored-guard.master/opam
@@ -1,9 +1,9 @@
 opam-version: "2.0"
 maintainer: "xen-api@lists.xen.org"
 authors: [ "xen-api@lists.xen.org" ]
-homepage: "https://github.com/xapi-project/varstored-guard"
-dev-repo: "git+https://github.com/xapi-project/varstored-guard.git"
-bug-reports: "https://github.com/xapi-project/varstored-guard"
+homepage: "https://github.com/xapi-project/xen-api"
+dev-repo: "git+https://github.com/xapi-project/xen-api.git"
+bug-reports: "https://github.com/xapi-project/xen-api"
 build: [["dune" "build" "-p" name "-j" jobs]]
 run-test: [[ "dune" "runtest" "-p" name "-j" jobs ]]
 depends: [
@@ -17,5 +17,5 @@ depends: [
 synopsis: "Supervising daemon for varstored daemons"
 description: ""
 url {
-  src: "https://github.com/xapi-project/varstored-guard/archive/master.tar.gz"
+  src: "https://github.com/xapi-project/xen-api/archive/master.tar.gz"
 }

--- a/packages/xs-extra/vhd-tool.master/opam
+++ b/packages/xs-extra/vhd-tool.master/opam
@@ -12,7 +12,8 @@ build: [[ "dune" "build" "-p" name "-j" jobs ]
 ]
 depends: [
   "ocaml"
-  "dune" {build}
+  "dune"
+  "alcotest-lwt" {with-test}
   "cohttp-lwt"
   "conf-libssl"
   "cstruct" {>= "3.0.0"}

--- a/packages/xs-extra/wsproxy.master/opam
+++ b/packages/xs-extra/wsproxy.master/opam
@@ -3,9 +3,9 @@ name: "wsproxy"
 maintainer: "xen-api@lists.xen.org"
 authors: [ "Jon Ludlam" "Marcello Seri" ]
 license: "LGPL-2.0-only WITH OCaml-LGPL-linking-exception"
-homepage: "https://github.com/xapi-project/wsproxy"
-dev-repo: "git+https://github.com/xapi-project/wsproxy.git"
-bug-reports: "https://github.com/xapi-project/wsproxy/issues"
+homepage: "https://github.com/xapi-project/xen-api"
+dev-repo: "git+https://github.com/xapi-project/xen-api.git"
+bug-reports: "https://github.com/xapi-project/xen-api/issues"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
@@ -25,5 +25,5 @@ depends: [
 tags: [ "org:xapi-project" ]
 synopsis: "Websockets proxy for VNC traffic"
 url {
-  src: "https://github.com/xapi-project/wsproxy/archive/master.tar.gz"
+  src: "https://github.com/xapi-project/xen-api/archive/master.tar.gz"
 }

--- a/packages/xs-extra/xapi-nbd.master/opam
+++ b/packages/xs-extra/xapi-nbd.master/opam
@@ -1,16 +1,16 @@
 opam-version: "2.0"
 maintainer: "xen-api@lists.xen.org"
 authors: ["dave.scott@citrix.com"]
-homepage: "https://github.com/xapi-project/xapi-nbd"
-bug-reports: "https://github.com/xapi-project/xapi-nbd/issues"
-dev-repo: "git+https://github.com/xapi-project/xapi-nbd.git"
+homepage: "https://github.com/xapi-project/xen-api"
+bug-reports: "https://github.com/xapi-project/xen-api/issues"
+dev-repo: "git+https://github.com/xapi-project/xen-api.git"
 build: [
-  [make "release"]
-  ["dune" "runtest" "-j" jobs] {with-test}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
   "ocaml"
-  "dune" {build}
+  "dune"
   "alcotest" {with-test}
   "alcotest-lwt" {with-test}
   "cmdliner"
@@ -27,5 +27,5 @@ tags: [ "org:mirage" "org:xapi-project" ]
 synopsis: "Expose XenServer disks conveniently over NBD"
 url {
   src:
-    "https://github.com/xapi-project/xapi-nbd/archive/master.tar.gz"
+    "https://github.com/xapi-project/xen-api/archive/master.tar.gz"
 }

--- a/packages/xs-extra/xapi-networkd.master/opam
+++ b/packages/xs-extra/xapi-networkd.master/opam
@@ -21,6 +21,7 @@ depends: [
   "xapi-idl"
   "xapi-inventory"
   "xapi-stdext-pervasives"
+  "xapi-stdext-std"
   "xapi-stdext-threads"
   "xapi-stdext-unix"
   "xapi-test-utils"

--- a/packages/xs-extra/xapi-storage-cli.master/opam
+++ b/packages/xs-extra/xapi-storage-cli.master/opam
@@ -3,9 +3,9 @@ name: "xapi-storage-cli"
 maintainer: "xen-api@lists.xen.org"
 authors: [ "xen-api@lists.xen.org" ]
 license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
-homepage: "https://github.com/xapi-project/sm-cli"
-bug-reports: "https://github.com/xapi-project/sm-cli/issues"
-dev-repo: "git+https://github.com/xapi-project/sm-cli.git"
+homepage: "https://github.com/xapi-project/xen-api"
+bug-reports: "https://github.com/xapi-project/xen-api/issues"
+dev-repo: "git+https://github.com/xapi-project/xen-api.git"
 build: [[ "dune" "build" "-p" name "-j" jobs ]]
 depends: [
   "ocaml"
@@ -22,5 +22,5 @@ description: """
 The CLI allows you to directly manipulate virtual disk images, without
 them being attached to VMs."""
 url {
-  src: "https://github.com/xapi-project/sm-cli/archive/master.tar.gz"
+  src: "https://github.com/xapi-project/xen-api/archive/master.tar.gz"
 }

--- a/packages/xs-extra/xapi-xenopsd-xc.master/opam
+++ b/packages/xs-extra/xapi-xenopsd-xc.master/opam
@@ -23,6 +23,7 @@ depends: [
   "fmt"
   "forkexec"
   "mtime"
+  "polly"
   "ppx_deriving_rpc"
   "ppx_sexp_conv"
   "qmp"

--- a/packages/xs-extra/xen-api-client-async.master/opam
+++ b/packages/xs-extra/xen-api-client-async.master/opam
@@ -5,17 +5,17 @@ license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 homepage: "https://github.com/xapi-project/xen-api"
 dev-repo: "git+https://github.com/xapi-project/xen-api.git"
 bug-reports: "https://github.com/xapi-project/xen-api/issues"
-
 tags: [
-  "org:mirage"
   "org:xapi-project"
 ]
-
-build: [[ "dune" "build" "-p" name "-j" jobs]]
-
+build-env: [[ XAPI_VERSION = "v0.0.0" ]]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
 depends: [
   "ocaml"
-  "dune" {build}
+  "dune"
   "async" {>= "v0.9.0"}
   "async_unix"
   "base-threads"
@@ -28,7 +28,7 @@ depends: [
   "ounit" {with-test}
 ]
 synopsis:
-  "Xen-API client library for remotely-controlling an XCP or XenServer host"
+  "Xen-API client library for remotely-controlling a xapi host"
 url {
   src: "https://github.com/xapi-project/xen-api/archive/master.tar.gz"
 }

--- a/packages/xs-extra/xen-api-client-lwt.master/opam
+++ b/packages/xs-extra/xen-api-client-lwt.master/opam
@@ -5,17 +5,17 @@ license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 homepage: "https://github.com/xapi-project/xen-api"
 dev-repo: "git+https://github.com/xapi-project/xen-api.git"
 bug-reports: "https://github.com/xapi-project/xen-api/issues"
-
 tags: [
-  "org:mirage"
   "org:xapi-project"
 ]
-
-build: [[ "dune" "build" "-p" name "-j" jobs]]
-
+build-env: [[ XAPI_VERSION = "v0.0.0" ]]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
 depends: [
   "ocaml"
-  "dune" {build}
+  "dune" {>= "1.4"}
   "cohttp" {>= "0.22.0"}
   "cohttp-lwt-unix"
   "cstruct" {>= "1.0.1"}
@@ -29,7 +29,7 @@ depends: [
   "ounit" {with-test}
 ]
 synopsis:
-  "Xen-API client library for remotely-controlling an XCP or XenServer host"
+  "Xen-API client library for remotely-controlling a xapi host"
 url {
   src: "https://github.com/xapi-project/xen-api/archive/master.tar.gz"
 }

--- a/packages/xs-extra/xen-api-client.master/opam
+++ b/packages/xs-extra/xen-api-client.master/opam
@@ -1,24 +1,21 @@
 opam-version: "2.0"
-name: "xen-api-client"
 maintainer: "xen-api@lists.xen.org"
 authors: [ "David Scott" "Anil Madhavapeddy" "Jerome Maloberti" "John Else" "Jon Ludlam" "Thomas Sanders" "Mike McClurg" ]
 license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 homepage: "https://github.com/xapi-project/xen-api"
 dev-repo: "git+https://github.com/xapi-project/xen-api.git"
 bug-reports: "https://github.com/xapi-project/xen-api/issues"
-
 tags: [
-  "org:mirage"
   "org:xapi-project"
 ]
-
+build-env: [[ XAPI_VERSION = "v0.0.0" ]]
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
   "ocaml"
-  "dune" {build & >= "1.0+beta11"}
+  "dune" {"1.4"}
   "astring"
   "cohttp" {>= "0.22.0"}
   "re"
@@ -32,7 +29,7 @@ depends: [
   "ounit" {with-test}
 ]
 synopsis:
-  "Xen-API client library for remotely-controlling an XCP or XenServer host"
+  "Xen-API client library for remotely-controlling a xapi host"
 url {
   src: "https://github.com/xapi-project/xen-api/archive/master.tar.gz"
 }

--- a/tools/generate-opam-sources.sh
+++ b/tools/generate-opam-sources.sh
@@ -9,7 +9,7 @@ XSER="xenserver"
 MAP="\
 rrd2csv                   $XAPI/xen-api
 rrddump                   $XAPI/xen-api
-varstored-guard           $XAPI/varstored-guard
+varstored-guard           $XAPI/xen-api
 xen-api-client-lwt        $XAPI/xen-api
 xen-api-client            $XAPI/xen-api
 xen-api-client-async      $XAPI/xen-api
@@ -40,8 +40,8 @@ vhd-tool                  $XAPI/xen-api
 xen-api-sdk               $XAPI/xen-api
 xapi-plugin               $XAPI/ocaml-xapi-plugin
 xapi-storage-script       $XAPI/xen-api
-xapi-storage-cli          $XAPI/sm-cli
-xapi-nbd                  $XAPI/xapi-nbd
+xapi-storage-cli          $XAPI/xen-api
+xapi-nbd                  $XAPI/xen-api
 uuid                      $XAPI/xen-api
 http-svr                  $XAPI/xen-api
 safe-resources            $XAPI/xen-api
@@ -60,7 +60,7 @@ xapi-rrd-transport        $XAPI/xen-api
 xapi-rrdd                 $XAPI/xen-api
 rrd-transport             $XAPI/xen-api
 xenctrl                   $XAPI/xenctrl
-wsproxy                   $XAPI/wsproxy
+wsproxy                   $XAPI/xen-api
 xapi-idl                  $XAPI/xen-api"
 
 echo "$MAP" | while read -r opam repo; do


### PR DESCRIPTION
The only repositories that are tracked by tools/generate-opam-sources.sh and are not hosted in xen-api are
- xapi-plugin: https://github.com/xapi-project/ocaml-xapi-plugin/
- xenctrl: https://github.com/xapi-project/xenctrl  