### PR TITLE
upstream: Replace 'typeof OCaml system' with a recognized SPDX

### DIFF
--- a/packages/upstream/stdlib-shims.0.3.0/opam
+++ b/packages/upstream/stdlib-shims.0.3.0/opam
@@ -11,7 +11,7 @@ This allows projects that require compatibility with older compiler to
 use these new features in their code."""
 maintainer: "The stdlib-shims programmers"
 authors: "The stdlib-shims programmers"
-license: "typeof OCaml system"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 tags: ["stdlib" "compatibility" "org:ocaml"]
 homepage: "https://github.com/ocaml/stdlib-shims"
 doc: "https://ocaml.github.io/stdlib-shims/"

--- a/packages/upstream/uchar.0.0.2/opam
+++ b/packages/upstream/uchar.0.0.2/opam
@@ -6,7 +6,7 @@ doc: "https://ocaml.github.io/uchar/"
 dev-repo: "git+https://github.com/ocaml/uchar.git"
 bug-reports: "https://github.com/ocaml/uchar/issues"
 tags: [ "text" "character" "unicode" "compatibility" "org:ocaml.org" ]
-license: "typeof OCaml system"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 depends: [
   "ocaml" {>= "3.12.0"}
   "ocamlbuild" {build}


### PR DESCRIPTION
Signed-off-by: Pau Ruiz Safont <pau.safont@citrix.com>