### PR TITLE
CP-38617: expose xentoollog as a package and use it

### DIFF
--- a/packages/xs-extra/xapi-xenopsd-xc.master/opam
+++ b/packages/xs-extra/xapi-xenopsd-xc.master/opam
@@ -46,6 +46,7 @@ depends: [
   "xenctrl"
   "xenstore"
   "xenstore_transport"
+  "xentoollog"
 ]
 synopsis:
   "A xenops plugin which knows how to use xenstore, xenctrl and xenguest to manage"

--- a/packages/xs-extra/xentoollog.master/opam
+++ b/packages/xs-extra/xentoollog.master/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-synopsis: "Mock OCaml bindings for the Xen Hypervisor"
+synopsis: "Mock OCaml bindings for Xen's xentoollog"
 maintainer: "xen-api@lists.xen.org"
 authors: "Christian Lindig <christian.lindig@citrix.com>"
 license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
@@ -7,7 +7,6 @@ homepage: "https://github.com/xapi-project/xenctrl"
 bug-reports: "https://github.com/xapi-project/xenctrl/issues"
 depends: [
   "ocaml"
-  "conf-xen"
   "dune" {>= "2.0"}
   "base-unix"
 ]


### PR DESCRIPTION
This package is not to be installed in the product and is only used to
ease local development.

Depends on https://github.com/xapi-project/xenctrl/pull/4 being merged