### PR TITLE
xs-extra: xapi-xenopsd now uses zstd for compression

### DIFF
--- a/packages/xs-extra/xapi-xenopsd.master/opam
+++ b/packages/xs-extra/xapi-xenopsd.master/opam
@@ -40,6 +40,7 @@ depends: [
   "xenctrl"
   "xenstore_transport" {with-test}
   "xmlm"
+  "zstd"
 ]
 synopsis: "A single-host domain/VM manager for the Xen hypervisor"
 description: """


### PR DESCRIPTION
This fixes the build: https://github.com/xapi-project/xs-opam/runs/7227011614