### PR TITLE
Update repos to point to lcm branches to keep up with yangtze's hotfixes

### DIFF
--- a/packages/xs-extra/xapi-networkd.0.56/opam
+++ b/packages/xs-extra/xapi-networkd.0.56/opam
@@ -30,5 +30,5 @@ depends: [
 synopsis: "The XCP networking daemon"
 url {
   src:
-    "https://github.com/xapi-project/xcp-networkd/archive/v0.56.1.tar.gz"
+    "https://github.com/xapi-project/xcp-networkd/archive/0.56-lcm.tar.gz"
 }


### PR DESCRIPTION
Now that xapi-networkd 0.56.1 has been released stop using a tag and use instead the
lcm branch, like other repos do.

Signed-off-by: Pau Ruiz Safont <pau.safont@citrix.com>