### PR TITLE
xs-extra: xen-api packages don't need to set XAPI_VERSION anymore

### DIFF
--- a/packages/xs-extra/xapi-cli-protocol.master/opam
+++ b/packages/xs-extra/xapi-cli-protocol.master/opam
@@ -4,7 +4,6 @@ authors: [ "xen-api@lists.xen.org" ]
 homepage: "https://github.com/xapi-project/xen-api"
 bug-reports: "https://github.com/xapi-project/xen-api/issues"
 dev-repo: "git+https://github.com/xapi-project/xen-api.git"
-build-env: [[ XAPI_VERSION = "v0.0.0" ]]
 build: [
   ["dune" "build" "-p" name "-j" jobs ]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}

--- a/packages/xs-extra/xapi-client.master/opam
+++ b/packages/xs-extra/xapi-client.master/opam
@@ -4,7 +4,6 @@ authors: [ "xen-api@lists.xen.org" ]
 homepage: "https://github.com/xapi-project/xen-api"
 bug-reports: "https://github.com/xapi-project/xen-api/issues"
 dev-repo: "git+https://github.com/xapi-project/xen-api.git"
-build-env: [[ XAPI_VERSION = "v0.0.0" ]]
 build: [
   ["dune" "build" "-p" name "-j" jobs ]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}

--- a/packages/xs-extra/xapi-consts.master/opam
+++ b/packages/xs-extra/xapi-consts.master/opam
@@ -4,7 +4,6 @@ authors: [ "xen-api@lists.xen.org" ]
 homepage: "https://github.com/xapi-project/xen-api"
 bug-reports: "https://github.com/xapi-project/xen-api/issues"
 dev-repo: "git+https://github.com/xapi-project/xen-api.git"
-build-env: [[ XAPI_VERSION = "v0.0.0" ]]
 build: [
   ["dune" "build" "-p" name "-j" jobs ]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}

--- a/packages/xs-extra/xapi-database.master/opam
+++ b/packages/xs-extra/xapi-database.master/opam
@@ -4,7 +4,6 @@ authors: [ "xen-api@lists.xen.org" ]
 homepage: "https://github.com/xapi-project/xen-api"
 bug-reports: "https://github.com/xapi-project/xen-api/issues"
 dev-repo: "git+https://github.com/xapi-project/xen-api.git"
-build-env: [[ XAPI_VERSION = "v0.0.0" ]]
 build: [
   ["dune" "build" "-p" name "-j" jobs ]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}

--- a/packages/xs-extra/xapi-datamodel.master/opam
+++ b/packages/xs-extra/xapi-datamodel.master/opam
@@ -4,7 +4,6 @@ authors: [ "xen-api@lists.xen.org" ]
 homepage: "https://github.com/xapi-project/xen-api"
 bug-reports: "https://github.com/xapi-project/xen-api/issues"
 dev-repo: "git+https://github.com/xapi-project/xen-api.git"
-build-env: [[ XAPI_VERSION = "v0.0.0" ]]
 build: [
   ["dune" "build" "-p" name "-j" jobs ]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}

--- a/packages/xs-extra/xapi-types.master/opam
+++ b/packages/xs-extra/xapi-types.master/opam
@@ -4,7 +4,6 @@ authors: [ "xen-api@lists.xen.org" ]
 homepage: "https://github.com/xapi-project/xen-api"
 bug-reports: "https://github.com/xapi-project/xen-api/issues"
 dev-repo: "git+https://github.com/xapi-project/xen-api.git"
-build-env: [[ XAPI_VERSION = "v0.0.0" ]]
 build: [
   ["dune" "build" "-p" name "-j" jobs ]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}

--- a/packages/xs-extra/xapi.master/opam
+++ b/packages/xs-extra/xapi.master/opam
@@ -4,7 +4,6 @@ authors: [ "xen-api@lists.xen.org" ]
 homepage: "https://github.com/xapi-project/xen-api"
 bug-reports: "https://github.com/xapi-project/xen-api/issues"
 dev-repo: "git+https://github.com/xapi-project/xen-api.git"
-build-env: [[ XAPI_VERSION = "v0.0.0" ]]
 build: [
   ["dune" "build" "-p" name "-j" jobs ]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}

--- a/packages/xs-extra/xe.master/opam
+++ b/packages/xs-extra/xe.master/opam
@@ -4,7 +4,6 @@ authors: [ "xen-api@lists.xen.org" ]
 homepage: "https://github.com/xapi-project/xen-api"
 bug-reports: "https://github.com/xapi-project/xen-api/issues"
 dev-repo: "git+https://github.com/xapi-project/xen-api.git"
-build-env: [[ XAPI_VERSION = "v0.0.0" ]]
 build: [
   ["dune" "build" "-p" name "-j" jobs ]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}

--- a/packages/xs-extra/xen-api-client-async.master/opam
+++ b/packages/xs-extra/xen-api-client-async.master/opam
@@ -8,7 +8,6 @@ bug-reports: "https://github.com/xapi-project/xen-api/issues"
 tags: [
   "org:xapi-project"
 ]
-build-env: [[ XAPI_VERSION = "v0.0.0" ]]
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}

--- a/packages/xs-extra/xen-api-client-lwt.master/opam
+++ b/packages/xs-extra/xen-api-client-lwt.master/opam
@@ -8,7 +8,6 @@ bug-reports: "https://github.com/xapi-project/xen-api/issues"
 tags: [
   "org:xapi-project"
 ]
-build-env: [[ XAPI_VERSION = "v0.0.0" ]]
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}

--- a/packages/xs-extra/xen-api-client.master/opam
+++ b/packages/xs-extra/xen-api-client.master/opam
@@ -8,7 +8,6 @@ bug-reports: "https://github.com/xapi-project/xen-api/issues"
 tags: [
   "org:xapi-project"
 ]
-build-env: [[ XAPI_VERSION = "v0.0.0" ]]
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}


### PR DESCRIPTION
This is due to https://github.com/xapi-project/xen-api/pull/4779