### PR TITLE
xs-extra: add missing dependencies

### DIFF
--- a/packages/xs-extra/rrddump.master/opam
+++ b/packages/xs-extra/rrddump.master/opam
@@ -6,7 +6,7 @@ authors: "John Else"
 tags: "org:xapi-project"
 homepage: "https://github.com/xapi-project/xen-api"
 bug-reports: "https://github.com/xapi-project/xen-api/issues"
-depends: ["xapi-rrd" "xmlm"]
+depends: ["rrd-transport" "xapi-rrd" "xmlm"]
 build: ["dune" "build" "-p" name "-j" jobs]
 dev-repo: "git+https://github.com/xapi-project/xen-api.git"
 url {

--- a/packages/xs-extra/xapi-compression.master/opam
+++ b/packages/xs-extra/xapi-compression.master/opam
@@ -12,7 +12,6 @@ depends: [
   "dune"
   "forkexec"
   "safe-resources"
-  "xapi-idl"
   "xapi-log"
   "xapi-stdext-pervasives"
   "xapi-stdext-unix"

--- a/packages/xs-extra/xapi-consts.master/opam
+++ b/packages/xs-extra/xapi-consts.master/opam
@@ -11,6 +11,7 @@ build: [
 depends: [
   "ocaml"
   "dune" {build & >= "1.4"}
+  "dune-build-info"
   "xapi-inventory"
 ]
 synopsis: "The xapi toolstack daemon which implements the XenAPI"

--- a/packages/xs-extra/xapi-idl.master/opam
+++ b/packages/xs-extra/xapi-idl.master/opam
@@ -28,8 +28,6 @@ depends: [
   "re"
   "xapi-rrd"
   "sexplib"
-  "base-threads"
-  "base-unix"
   "uri"
   "xapi-backtrace"
   "xapi-open-uri"

--- a/packages/xs-extra/xapi-squeezed.master/opam
+++ b/packages/xs-extra/xapi-squeezed.master/opam
@@ -10,19 +10,22 @@ build: [
 ]
 depends: [
   "ocaml"
+  "astring"
+  "cohttp" {>= "0.11.0"}
   "dune"
+  "re"
+  "rpclib"
+  "uri"
   "uuid"
+  "xapi-idl"
+  "xapi-log"
   "xapi-stdext-pervasives"
   "xapi-stdext-threads"
   "xapi-stdext-unix"
-  "cohttp" {>= "0.11.0"}
-  "uri"
-  "re"
-  "rpclib"
-  "xapi-idl"
+  "xapi-types"
+  "xenctrl" {>= "0.9.20"}
   "xenstore"
   "xenstore_transport"
-  "xenctrl" {>= "0.9.20"}
 ]
 synopsis: "A memory ballooning daemon for the Xen hypervisor"
 description: """

--- a/packages/xs-extra/xapi.master/opam
+++ b/packages/xs-extra/xapi.master/opam
@@ -70,6 +70,7 @@ depexts: [
   ["hwdata" "libxxhash-dev" "libxxhash0"] {os-distribution = "ubuntu"}
   ["hwdata" "xxhash-devel" "xxhash-libs"] {os-distribution = "centos"}
   ["hwdata" "xxhash-devel" "xxhash-libs"] {os-distribution = "fedora"}
+  ["hwdata" "xxhash-dev" "xxhash"] {os-distribution = "alpine"}
 ]
 synopsis: "The xapi toolstack daemon which implements the XenAPI"
 description: """


### PR DESCRIPTION
These metadata changes depend on a dune metadata fix in https://github.com/xapi-project/xen-api/pull/4833