### PR TITLE
ocaml: add 4.14

### DIFF
--- a/.github/duplicates-upstream-extra.txt
+++ b/.github/duplicates-upstream-extra.txt
@@ -1,3 +1,9 @@
 ocaml
 ocaml-base-compiler
 ocaml-system
+merlin
+merlin-dot-reader
+ocaml-lsp-server
+ocamlformat
+ocamlformat-rpc-lib
+odoc-parser

--- a/.github/duplicates-xs-toolstack.txt
+++ b/.github/duplicates-xs-toolstack.txt
@@ -1,3 +1,5 @@
 ocaml
 ocaml-base-compiler
 ocaml-system
+ocamlformat
+odoc-parser

--- a/.github/unused-upstream.txt
+++ b/.github/unused-upstream.txt
@@ -1,5 +1,6 @@
 bisect_ppx
 conf-perl
+either
 fix
 logs-syslog
 memtrace

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,12 @@ jobs:
       fail-fast: false
       matrix:
         ocaml-version: ["4.13.1"]
+        experimental: [false]
+        include:
+          - ocaml-version: "4.14.1"
+            experimental: true
 
+    continue-on-error: ${{ matrix.experimental }}
     env:
       OCAML_VERSION: ${{ matrix.ocaml-version }}
 

--- a/packages/ocaml/ocaml-base-compiler.4.14.1/files/ocaml-base-compiler.install
+++ b/packages/ocaml/ocaml-base-compiler.4.14.1/files/ocaml-base-compiler.install
@@ -1,0 +1,1 @@
+share_root: ["config.cache" {"ocaml/config.cache"}]

--- a/packages/ocaml/ocaml-base-compiler.4.14.1/opam
+++ b/packages/ocaml/ocaml-base-compiler.4.14.1/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+name: "ocaml-base-compiler"
+version: "4.14.1"
+synopsis: "Official release 4.14.1"
+maintainer: "platform@lists.ocaml.org"
+authors: "Xavier Leroy and many contributors"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+depends: [
+  "ocaml" {= "4.14.1" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "ocaml-options-vanilla" {post}
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--docdir=%{doc}%/ocaml"
+    "-C"
+    "CC=cc" {os = "openbsd" | os = "macos"}
+    "ASPP=cc -c" {os = "openbsd" | os = "macos"}
+  ]
+  [make "-j%{jobs}%"]
+]
+install: [make "install"]
+post-messages: [
+  """\
+A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"""
+    {failure & jobs > "1"}
+  """\
+You can try installing again including --jobs=1
+   to force a sequential build instead."""
+    {failure & jobs > "1" & opam-version >= "2.0.5"}
+]
+dev-repo: "git+https://github.com/ocaml/ocaml"
+extra-files: [
+  "ocaml-base-compiler.install" "md5=3e969b841df1f51ca448e6e6295cb451"
+]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.14.1.tar.gz"
+  checksum:
+    "sha256=776006e6f0b9bcfb6d9d74381c588e587432ca85562fde93bb80472a5145b028"
+}

--- a/packages/ocaml/ocaml-system.4.14.1/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml/ocaml-system.4.14.1/files/gen_ocaml_config.ml.in
@@ -1,0 +1,43 @@
+let () =
+  let exe = ".exe" in
+  let ocamlc =
+    let (base, suffix) =
+      let s = Sys.executable_name in
+      if Filename.check_suffix s exe then
+        (Filename.chop_suffix s exe, exe)
+      else
+        (s, "") in
+    base ^ "c" ^ suffix in
+  if Sys.ocaml_version <> "%{_:version}%" then
+    (Printf.eprintf
+       "ERROR: The compiler found at %%s has version %%s,\n\
+        and this package requires %{_:version}%.\n\
+        You should use e.g. 'opam switch create %{_:name}%.%%s' \
+        instead."
+       ocamlc Sys.ocaml_version Sys.ocaml_version;
+     exit 1)
+  else
+  let ocamlc_digest = Digest.to_hex (Digest.file ocamlc) in
+  let libdir =
+    if Sys.command (ocamlc^" -where > %{_:name}%.config") = 0 then
+      let ic = open_in "%{_:name}%.config" in
+      let r = input_line ic in
+      close_in ic;
+      Sys.remove "%{_:name}%.config";
+      r
+    else
+      failwith "Bad return from 'ocamlc -where'"
+  in
+  let graphics = Filename.concat libdir "graphics.cmi" in
+  let graphics_digest =
+    if Sys.file_exists graphics then
+      Digest.to_hex (Digest.file graphics)
+    else
+      String.make 32 '0'
+  in
+  let oc = open_out "%{_:name}%.config" in
+  Printf.fprintf oc "opam-version: \"2.0\"\n\
+                     file-depends: [ [ %%S %%S ] [ %%S %%S ] ]\n\
+                     variables { path: %%S }\n"
+    ocamlc ocamlc_digest graphics graphics_digest (Filename.dirname ocamlc);
+  close_out oc

--- a/packages/ocaml/ocaml-system.4.14.1/opam
+++ b/packages/ocaml/ocaml-system.4.14.1/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+name: "ocaml-system"
+version: "4.14.1"
+synopsis: "The OCaml compiler (system version, from outside of opam)"
+maintainer: "platform@lists.ocaml.org"
+authors: "Xavier Leroy and many contributors"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+depends: [
+  "ocaml" {post}
+  "base-unix" {post}
+  "base-threads" {post}
+  "base-bigarray" {post}
+]
+conflict-class: "ocaml-core-compiler"
+available: sys-ocaml-version = "4.14.1"
+flags: compiler
+build: ["ocaml" "gen_ocaml_config.ml"]
+substs: "gen_ocaml_config.ml"
+dev-repo: "git+https://github.com/ocaml/ocaml"
+extra-files: [
+  "gen_ocaml_config.ml.in" "md5=093e7bec1ec95f9e4c6a313d73c5d840"
+]

--- a/packages/ocaml/ocaml.4.14.1/opam
+++ b/packages/ocaml/ocaml.4.14.1/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+name: "ocaml"
+version: "4.14.1"
+synopsis: "The OCaml compiler (virtual package)"
+description: """\
+This package requires a matching implementation of OCaml,
+and polls it to initialise specific variables like `ocaml:native-dynlink`"""
+maintainer: "platform@lists.ocaml.org"
+authors: [
+  "Xavier Leroy"
+  "Damien Doligez"
+  "Alain Frisch"
+  "Jacques Garrigue"
+  "Didier Rémy"
+  "Jérôme Vouillon"
+]
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+depends: [
+  "ocaml-config" {>= "2"}
+  "ocaml-base-compiler" {>= "4.14.1~" & < "4.14.2~"} |
+  "ocaml-variants" {>= "4.14.1~" & < "4.14.2~"} |
+  "ocaml-system" {>= "4.14.1" & < "4.14.2~"}
+]
+flags: conf
+setenv: [
+  [CAML_LD_LIBRARY_PATH = "%{_:stubsdir}%"]
+  [CAML_LD_LIBRARY_PATH += "%{lib}%/stublibs"]
+  [OCAML_TOPLEVEL_PATH = "%{toplevel}%"]
+]
+build: [
+  "ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name
+]
+build-env: CAML_LD_LIBRARY_PATH = ""

--- a/packages/upstream-extra/chrome-trace.3.7.0/opam
+++ b/packages/upstream-extra/chrome-trace.3.7.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+name: "chrome-trace"
+version: "3.7.0"
+synopsis: "Chrome trace event generation library"
+description:
+  "This library offers no backwards compatibility guarantees. Use at your own risk."
+maintainer: "Jane Street Group, LLC <opensource@janestreet.com>"
+authors: "Jane Street Group, LLC <opensource@janestreet.com>"
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.5"}
+  "ocaml" {>= "4.08.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  ["dune" "build" "-p" name "-j" jobs "@install" "@doc" {with-doc}]
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+url {
+  src: "https://github.com/ocaml/dune/releases/download/3.7.0/dune-3.7.0.tbz"
+  checksum: [
+    "sha256=e2d637c9d080318fedf5e71d2a29fb367624f82ac4a26e83df2b3a03550528b8"
+    "sha512=586e47ee45cd53a8c13095bde0b47de99aad9462d0a52199362140b5b654ca862597fa9f27f729a8cc594684ac46858848f9fa76f8f06dc8dc8ab8b1186a3295"
+  ]
+}
+x-commit-hash: "d3d628f2eda2278bd2df6e37452d8693f367fcfd"

--- a/packages/upstream-extra/dot-merlin-reader.4.6/opam
+++ b/packages/upstream-extra/dot-merlin-reader.4.6/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+name: "dot-merlin-reader"
+version: "4.6"
+synopsis: "Reads config files for merlin"
+description: """\
+Helper process: reads .merlin files and outputs the normalized content to
+  stdout."""
+maintainer: "defree@gmail.com"
+authors: "The Merlin team"
+license: "MIT"
+homepage: "https://github.com/ocaml/merlin"
+bug-reports: "https://github.com/ocaml/merlin/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.9.0"}
+  "merlin-lib" {>= "4.6"}
+  "ocamlfind" {>= "1.6.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/ocaml/merlin.git"
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v4.6-414/merlin-4.6-414.tbz"
+  checksum: [
+    "sha256=02ebd70a3c77d8940163dbe4c40774a448ed145ea84e0ad3d5ff5324410393ce"
+    "sha512=7373fadf05c692c9f054c7fe6a7d4bdfeefe237b9df432024ef9923782ee72e09021c0c3fba869da8347728105cb2d3ff0aa94b0c5eb09811bb25aa8da9fb520"
+  ]
+}
+x-commit-hash: "be753d9412387aedcf32aba88a1be9bcd33d97ba"

--- a/packages/upstream-extra/dune-rpc.3.6.2/opam
+++ b/packages/upstream-extra/dune-rpc.3.6.2/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+name: "dune-rpc"
+version: "3.6.2"
+synopsis: "Communicate with dune using rpc"
+description: "Library to connect and control a running dune instance"
+maintainer: "Jane Street Group, LLC <opensource@janestreet.com>"
+authors: "Jane Street Group, LLC <opensource@janestreet.com>"
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.5"}
+  "csexp"
+  "ordering"
+  "dyn"
+  "xdg"
+  "stdune" {= version}
+  "pp" {>= "1.1.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  ["dune" "build" "-p" name "-j" jobs "@install" "@doc" {with-doc}]
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+url {
+  src: "https://github.com/ocaml/dune/releases/download/3.6.2/dune-3.6.2.tbz"
+  checksum: [
+    "sha256=b6d4ab848efb04aa2a325d0015d32ed4414ed7130ec7aa12f98158eff445cf3c"
+    "sha512=d0dd69ada2f1583319a2d6f679b8d49998059117c3258805ee69ae3e71d47bfab7a9c646f19b5fc43a6ccdef934eb87de5bb81205fcd60968bed8bf1790cf0a3"
+  ]
+}
+x-commit-hash: "c939c2b0f7a470cedd189988c61cd307a3cedace"

--- a/packages/upstream-extra/dyn.3.6.2/opam
+++ b/packages/upstream-extra/dyn.3.6.2/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+name: "dyn"
+version: "3.6.2"
+synopsis: "Dynamic type"
+description: "Dynamic type"
+maintainer: "Jane Street Group, LLC <opensource@janestreet.com>"
+authors: "Jane Street Group, LLC <opensource@janestreet.com>"
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.5"}
+  "ocaml" {>= "4.08.0"}
+  "ordering" {= version}
+  "pp" {>= "1.1.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  ["dune" "build" "-p" name "-j" jobs "@install" "@doc" {with-doc}]
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+url {
+  src: "https://github.com/ocaml/dune/releases/download/3.6.2/dune-3.6.2.tbz"
+  checksum: [
+    "sha256=b6d4ab848efb04aa2a325d0015d32ed4414ed7130ec7aa12f98158eff445cf3c"
+    "sha512=d0dd69ada2f1583319a2d6f679b8d49998059117c3258805ee69ae3e71d47bfab7a9c646f19b5fc43a6ccdef934eb87de5bb81205fcd60968bed8bf1790cf0a3"
+  ]
+}
+x-commit-hash: "c939c2b0f7a470cedd189988c61cd307a3cedace"

--- a/packages/upstream-extra/fiber.3.6.2/opam
+++ b/packages/upstream-extra/fiber.3.6.2/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+name: "fiber"
+version: "3.6.2"
+synopsis: "Structured concurrency library"
+description:
+  "This library offers no backwards compatibility guarantees. Use at your own risk."
+maintainer: "Jane Street Group, LLC <opensource@janestreet.com>"
+authors: "Jane Street Group, LLC <opensource@janestreet.com>"
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.5"}
+  "ocaml" {>= "4.08.0"}
+  "stdune" {= version}
+  "dyn" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  ["dune" "build" "-p" name "-j" jobs "@install" "@doc" {with-doc}]
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+url {
+  src: "https://github.com/ocaml/dune/releases/download/3.6.2/dune-3.6.2.tbz"
+  checksum: [
+    "sha256=b6d4ab848efb04aa2a325d0015d32ed4414ed7130ec7aa12f98158eff445cf3c"
+    "sha512=d0dd69ada2f1583319a2d6f679b8d49998059117c3258805ee69ae3e71d47bfab7a9c646f19b5fc43a6ccdef934eb87de5bb81205fcd60968bed8bf1790cf0a3"
+  ]
+}
+x-commit-hash: "c939c2b0f7a470cedd189988c61cd307a3cedace"

--- a/packages/upstream-extra/merlin-lib.4.6-414/opam
+++ b/packages/upstream-extra/merlin-lib.4.6-414/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+name: "merlin-lib"
+version: "4.6-414"
+synopsis: "Merlin's libraries"
+description: """\
+These libraries provides access to low-level compiler interfaces and the
+  standard higher-level merlin protocol. The library is provided as-is, is not
+  thoroughly documented, and its public API might break with any new release."""
+maintainer: "defree@gmail.com"
+authors: "The Merlin team"
+license: "MIT"
+homepage: "https://github.com/ocaml/merlin"
+bug-reports: "https://github.com/ocaml/merlin/issues"
+depends: [
+  "ocaml" {>= "4.14" & < "4.15"}
+  "dune" {>= "2.9.0"}
+  "csexp" {>= "1.5.1"}
+  "menhir" {dev}
+  "menhirLib" {dev}
+  "menhirSdk" {dev}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/ocaml/merlin.git"
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v4.6-414/merlin-4.6-414.tbz"
+  checksum: [
+    "sha256=02ebd70a3c77d8940163dbe4c40774a448ed145ea84e0ad3d5ff5324410393ce"
+    "sha512=7373fadf05c692c9f054c7fe6a7d4bdfeefe237b9df432024ef9923782ee72e09021c0c3fba869da8347728105cb2d3ff0aa94b0c5eb09811bb25aa8da9fb520"
+  ]
+}
+x-commit-hash: "be753d9412387aedcf32aba88a1be9bcd33d97ba"

--- a/packages/upstream-extra/merlin.4.6-414/opam
+++ b/packages/upstream-extra/merlin.4.6-414/opam
@@ -1,0 +1,78 @@
+opam-version: "2.0"
+name: "merlin"
+version: "4.6-414"
+synopsis:
+  "Editor helper, provides completion, typing and source browsing in Vim and Emacs"
+description:
+  "Merlin is an assistant for editing OCaml code. It aims to provide the features available in modern IDEs: error reporting, auto completion, source browsing and much more."
+maintainer: "defree@gmail.com"
+authors: "The Merlin team"
+license: "MIT"
+homepage: "https://github.com/ocaml/merlin"
+bug-reports: "https://github.com/ocaml/merlin/issues"
+depends: [
+  "ocaml" {>= "4.14" & < "4.15"}
+  "dune" {>= "2.9.0"}
+  "merlin-lib" {= version}
+  "dot-merlin-reader" {>= "4.6"}
+  "yojson" {>= "2.0.0"}
+  "conf-jq" {with-test}
+]
+conflicts: [
+  "seq" {!= "base"}
+  "base-effects"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+post-messages:
+  """\
+merlin installed.
+
+Quick setup for VIM
+-------------------
+Append this to your .vimrc to add merlin to vim's runtime-path:
+  let g:opamshare = substitute(system('opam var share'),'\\n$','','''')
+  execute "set rtp+=" . g:opamshare . "/merlin/vim"
+
+Also run the following line in vim to index the documentation:
+  :execute "helptags " . g:opamshare . "/merlin/vim/doc"
+
+Quick setup for EMACS
+-------------------
+Add opam emacs directory to your load-path by appending this to your .emacs:
+  (let ((opam-share (ignore-errors (car (process-lines "opam" "var" "share")))))
+   (when (and opam-share (file-directory-p opam-share))
+    ;; Register Merlin
+    (add-to-list 'load-path (expand-file-name "emacs/site-lisp" opam-share))
+    (autoload 'merlin-mode "merlin" nil t nil)
+    ;; Automatically start it in OCaml buffers
+    (add-hook 'tuareg-mode-hook 'merlin-mode t)
+    (add-hook 'caml-mode-hook 'merlin-mode t)
+    ;; Use opam switch to lookup ocamlmerlin binary
+    (setq merlin-command 'opam)))
+
+Take a look at https://github.com/ocaml/merlin for more information
+
+Quick setup with opam-user-setup
+--------------------------------
+
+Opam-user-setup support Merlin.
+
+  $ opam user-setup install
+
+should take care of basic setup.
+See https://github.com/OCamlPro/opam-user-setup"""
+    {success & !user-setup:installed}
+dev-repo: "git+https://github.com/ocaml/merlin.git"
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v4.6-414/merlin-4.6-414.tbz"
+  checksum: [
+    "sha256=02ebd70a3c77d8940163dbe4c40774a448ed145ea84e0ad3d5ff5324410393ce"
+    "sha512=7373fadf05c692c9f054c7fe6a7d4bdfeefe237b9df432024ef9923782ee72e09021c0c3fba869da8347728105cb2d3ff0aa94b0c5eb09811bb25aa8da9fb520"
+  ]
+}
+x-commit-hash: "be753d9412387aedcf32aba88a1be9bcd33d97ba"

--- a/packages/upstream-extra/ocaml-lsp-server.1.15.1-4.14/opam
+++ b/packages/upstream-extra/ocaml-lsp-server.1.15.1-4.14/opam
@@ -1,0 +1,61 @@
+opam-version: "2.0"
+name: "ocaml-lsp-server"
+version: "1.15.1-4.14"
+synopsis: "LSP Server for OCaml"
+description: "An LSP server for OCaml."
+maintainer: "Rudi Grinberg <me@rgrinberg.com>"
+authors: [
+  "Andrey Popp <8mayday@gmail.com>"
+  "Rusty Key <iam@stfoo.ru>"
+  "Louis Roché <louis@louisroche.net>"
+  "Oleksiy Golovko <alexei.golovko@gmail.com>"
+  "Rudi Grinberg <me@rgrinberg.com>"
+  "Sacha Ayoun <sachaayoun@gmail.com>"
+  "cannorin <cannorin@gmail.com>"
+  "Ulugbek Abdullaev <ulugbekna@gmail.com>"
+  "Thibaut Mattio <thibaut.mattio@gmail.com>"
+  "Max Lantas <mnxndev@outlook.com>"
+]
+license: "ISC"
+homepage: "https://github.com/ocaml/ocaml-lsp"
+bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "yojson"
+  "re" {>= "1.5.0"}
+  "ppx_yojson_conv_lib" {>= "v0.14"}
+  "dune-rpc" {>= "3.4.0"}
+  "chrome-trace" {>= "3.3.0"}
+  "dyn"
+  "stdune"
+  "fiber" {>= "3.1.1"}
+  "xdg"
+  "ordering"
+  "dune-build-info"
+  "spawn"
+  "ppx_expect" {>= "v0.15.0" & with-test}
+  "ocamlformat" {with-test & = "0.24.1"}
+  "ocamlc-loc" {>= "3.5.0" & < "3.7.0"}
+  "omd" {>= "1.3.2" & < "2.0.0~alpha1"}
+  "octavius" {>= "1.2.2"}
+  "uutf" {>= "1.0.2"}
+  "pp" {>= "1.1.2"}
+  "csexp" {>= "1.5"}
+  "ocamlformat-rpc-lib" {>= "0.21.0"}
+  "odoc" {with-doc}
+  "ocaml" {>= "4.14" & < "4.15"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-j" jobs "ocaml-lsp-server.install" "--release"]
+]
+dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
+url {
+  src:
+    "https://github.com/ocaml/ocaml-lsp/releases/download/1.15.1-4.14/lsp-1.15.1-4.14.tbz"
+  checksum: [
+    "sha256=9e8e1edb067b0b6edc9b8081f1c046427afc6d5d422fe88a9bf2f8076ab9826d"
+    "sha512=28e4511404e808c066b05cde1f047f82819f30ca689d9c906b716743c0a53002ab1993202204302455ae45ce591868cc80490c01ea4fe672e95ce46e62fd2a39"
+  ]
+}
+x-commit-hash: "38849b2a14355e97532e8866c29a88d966dd8b47"

--- a/packages/upstream-extra/ocamlc-loc.3.6.2/opam
+++ b/packages/upstream-extra/ocamlc-loc.3.6.2/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+name: "ocamlc-loc"
+version: "3.6.2"
+synopsis: "Parse ocaml compiler output into structured form"
+description:
+  "This library offers no backwards compatibility guarantees. Use at your own risk."
+maintainer: "Jane Street Group, LLC <opensource@janestreet.com>"
+authors: "Jane Street Group, LLC <opensource@janestreet.com>"
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.5"}
+  "ocaml" {>= "4.08.0"}
+  "dyn" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  ["dune" "build" "-p" name "-j" jobs "@install" "@doc" {with-doc}]
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+url {
+  src: "https://github.com/ocaml/dune/releases/download/3.6.2/dune-3.6.2.tbz"
+  checksum: [
+    "sha256=b6d4ab848efb04aa2a325d0015d32ed4414ed7130ec7aa12f98158eff445cf3c"
+    "sha512=d0dd69ada2f1583319a2d6f679b8d49998059117c3258805ee69ae3e71d47bfab7a9c646f19b5fc43a6ccdef934eb87de5bb81205fcd60968bed8bf1790cf0a3"
+  ]
+}
+x-commit-hash: "c939c2b0f7a470cedd189988c61cd307a3cedace"

--- a/packages/upstream-extra/ocamlformat-rpc-lib.0.22.4/opam
+++ b/packages/upstream-extra/ocamlformat-rpc-lib.0.22.4/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+name: "ocamlformat-rpc-lib"
+version: "0.22.4"
+synopsis: "Auto-formatter for OCaml code (RPC mode)"
+description:
+  "OCamlFormat is a tool to automatically format OCaml code in a uniform style. This package defines a RPC interface to OCamlFormat"
+maintainer: "OCamlFormat Team <ocamlformat-dev@lists.ocaml.org>"
+authors: "Josh Berdine <jjb@fb.com>"
+license: "MIT"
+homepage: "https://github.com/ocaml-ppx/ocamlformat"
+bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.08"}
+  "csexp" {>= "1.4.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
+url {
+  src:
+    "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.22.4/ocamlformat-0.22.4.tbz"
+  checksum: [
+    "sha256=eb54de2b81ac7cc2e68d81a7dc80b391a81b737fcfa3ef969ea91bdad6c9c060"
+    "sha512=2bdeb9abc5757176040f641b22c59ac2b038c3bc1c42ddf86422b80cb90278fbe8ca05d0f788be0375a632bb6584b8d165d07f9f84686c2174208a8c20324b13"
+  ]
+}
+x-commit-hash: "838ba9fa00cc27703441220b9a5d3880b17430fb"

--- a/packages/upstream-extra/octavius.1.2.2/opam
+++ b/packages/upstream-extra/octavius.1.2.2/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+name: "octavius"
+version: "1.2.2"
+synopsis: "Ocamldoc comment syntax parser"
+description: "Octavius is a library to parse the `ocamldoc` comment syntax."
+maintainer: "leo@lpw25.net"
+authors: "Leo White <leo@lpw25.net>"
+license: "ISC"
+homepage: "https://github.com/ocaml-doc/octavius"
+doc: "http://ocaml-doc.github.io/octavius/"
+bug-reports: "https://github.com/ocaml-doc/octavius/issues"
+depends: [
+  "dune" {>= "1.11"}
+  "ocaml" {>= "4.03.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-doc/octavius.git"
+url {
+  src: "https://github.com/ocaml-doc/octavius/archive/v1.2.2.tar.gz"
+  checksum: "md5=72f9e1d996e6c5089fc513cc9218607b"
+}

--- a/packages/upstream-extra/omd.1.3.2/opam
+++ b/packages/upstream-extra/omd.1.3.2/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+name: "omd"
+version: "1.3.2"
+synopsis: "A Markdown frontend in pure OCaml"
+description: """\
+This Markdown library is implemented using only pure OCaml (including
+I/O operations provided by the standard OCaml compiler distribution).
+OMD is meant to be as faithful as possible to the original Markdown.
+Additionally, OMD implements a few Github markdown features, an
+extension mechanism, and some other features. Note that the opam
+package installs both the OMD library and the command line tool `omd`."""
+maintainer: [
+  "Shon Feder <shon.feder@gmail.com>" "Raphael Sousa Santos <@sonologico>"
+]
+authors: [
+  "Philippe Wang <philippe.wang@gmail.com>"
+  "Nicolás Ojeda Bär <n.oje.bar@gmail.com>"
+]
+license: "ISC"
+tags: ["org:ocamllabs" "org:mirage"]
+homepage: "https://github.com/ocaml/omd"
+bug-reports: "https://github.com/ocaml/omd/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.04"}
+  "base-bigarray"
+  "base-bytes"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml/omd.git"
+url {
+  src: "https://github.com/ocaml/omd/releases/download/1.3.2/omd-1.3.2.tbz"
+  checksum: [
+    "sha256=6023e1642631f08f678eb5725820879ed7bb5a3ffee777cdedebc28c1f85fadb"
+    "sha512=fa2070a5f5d30b2cc422937ac4158bb087134a69d47fa15df403afb1c0c60a73dd436c949faa8d44e0b65bdee039779d86191b55085b717253f91ef20a69ef98"
+  ]
+}
+x-commit-hash: "bc6c0d568b90b61143e9863cb6ef7b3989b3313a"

--- a/packages/upstream-extra/ordering.3.6.2/opam
+++ b/packages/upstream-extra/ordering.3.6.2/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+name: "ordering"
+version: "3.6.2"
+synopsis: "Element ordering"
+description: "Element ordering"
+maintainer: "Jane Street Group, LLC <opensource@janestreet.com>"
+authors: "Jane Street Group, LLC <opensource@janestreet.com>"
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.5"}
+  "ocaml" {>= "4.08.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  ["dune" "build" "-p" name "-j" jobs "@install" "@doc" {with-doc}]
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+url {
+  src: "https://github.com/ocaml/dune/releases/download/3.6.2/dune-3.6.2.tbz"
+  checksum: [
+    "sha256=b6d4ab848efb04aa2a325d0015d32ed4414ed7130ec7aa12f98158eff445cf3c"
+    "sha512=d0dd69ada2f1583319a2d6f679b8d49998059117c3258805ee69ae3e71d47bfab7a9c646f19b5fc43a6ccdef934eb87de5bb81205fcd60968bed8bf1790cf0a3"
+  ]
+}
+x-commit-hash: "c939c2b0f7a470cedd189988c61cd307a3cedace"

--- a/packages/upstream-extra/stdune.3.6.2/opam
+++ b/packages/upstream-extra/stdune.3.6.2/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+name: "stdune"
+version: "3.6.2"
+synopsis: "Dune's unstable standard library"
+description:
+  "This library offers no backwards compatibility guarantees. Use at your own risk."
+maintainer: "Jane Street Group, LLC <opensource@janestreet.com>"
+authors: "Jane Street Group, LLC <opensource@janestreet.com>"
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.5"}
+  "ocaml" {>= "4.08.0"}
+  "base-unix"
+  "dyn" {= version}
+  "ordering" {= version}
+  "pp" {>= "1.1.0"}
+  "csexp" {>= "1.5.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  ["dune" "build" "-p" name "-j" jobs "@install" "@doc" {with-doc}]
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+url {
+  src: "https://github.com/ocaml/dune/releases/download/3.6.2/dune-3.6.2.tbz"
+  checksum: [
+    "sha256=b6d4ab848efb04aa2a325d0015d32ed4414ed7130ec7aa12f98158eff445cf3c"
+    "sha512=d0dd69ada2f1583319a2d6f679b8d49998059117c3258805ee69ae3e71d47bfab7a9c646f19b5fc43a6ccdef934eb87de5bb81205fcd60968bed8bf1790cf0a3"
+  ]
+}
+x-commit-hash: "c939c2b0f7a470cedd189988c61cd307a3cedace"

--- a/packages/upstream-extra/xdg.3.6.2/opam
+++ b/packages/upstream-extra/xdg.3.6.2/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+name: "xdg"
+version: "3.6.2"
+synopsis: "XDG Base Directory Specification"
+description:
+  "https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html"
+maintainer: "Jane Street Group, LLC <opensource@janestreet.com>"
+authors: "Jane Street Group, LLC <opensource@janestreet.com>"
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.5"}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  ["dune" "build" "-p" name "-j" jobs "@install" "@doc" {with-doc}]
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+url {
+  src: "https://github.com/ocaml/dune/releases/download/3.6.2/dune-3.6.2.tbz"
+  checksum: [
+    "sha256=b6d4ab848efb04aa2a325d0015d32ed4414ed7130ec7aa12f98158eff445cf3c"
+    "sha512=d0dd69ada2f1583319a2d6f679b8d49998059117c3258805ee69ae3e71d47bfab7a9c646f19b5fc43a6ccdef934eb87de5bb81205fcd60968bed8bf1790cf0a3"
+  ]
+}
+x-commit-hash: "c939c2b0f7a470cedd189988c61cd307a3cedace"

--- a/packages/upstream/either.1.0.0/opam
+++ b/packages/upstream/either.1.0.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+name: "either"
+version: "1.0.0"
+synopsis: "Compatibility Either module"
+description: """\
+Projects that want to use the Either module defined in OCaml 4.12.0 while
+staying compatible with older versions of OCaml should use this library
+instead."""
+maintainer: "Craig Ferguson <me@craigfe.io>"
+authors: "Craig Ferguson <me@craigfe.io>"
+license: "MIT"
+homepage: "https://github.com/mirage/either"
+doc: "https://mirage.github.io/either"
+bug-reports: "https://github.com/mirage/either/issues"
+depends: [
+  "dune" {>= "2.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/either.git"
+url {
+  src:
+    "https://github.com/mirage/either/releases/download/1.0.0/either-1.0.0.tbz"
+  checksum: [
+    "sha256=bf674de3312dee7b7215f07df1e8a96eb3d679164b8a918cdd95b8d97e505884"
+    "sha512=147854c09f897dd028b18a9f19acea8666107aaa7b1aab3c92f568af531364f57298edcaf3897d74246d3857d52e9bfb7ad0fc39220d988d9f14694ca1d5e9ed"
+  ]
+}
+x-commit-hash: "a270ceac58e3e5bed6fe7e8bfb7132b14ee9c322"

--- a/packages/upstream/ocamlformat.0.22.4/opam
+++ b/packages/upstream/ocamlformat.0.22.4/opam
@@ -1,0 +1,60 @@
+opam-version: "2.0"
+name: "ocamlformat"
+version: "0.22.4"
+synopsis: "Auto-formatter for OCaml code"
+description:
+  "OCamlFormat is a tool to automatically format OCaml code in a uniform style."
+maintainer: "OCamlFormat Team <ocamlformat-dev@lists.ocaml.org>"
+authors: "Josh Berdine <jjb@fb.com>"
+license: "MIT AND LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/ocaml-ppx/ocamlformat"
+bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "alcotest" {with-test}
+  "base" {>= "v0.12.0"}
+  "cmdliner" {>= "1.1.0"}
+  "dune" {>= "2.8"}
+  "dune" {with-test & < "3.0"}
+  "dune-build-info"
+  "either"
+  "fix"
+  "fpath"
+  "menhir" {>= "20201216"}
+  "menhirLib" {>= "20201216"}
+  "menhirSdk" {>= "20201216"}
+  "ocaml-version" {>= "3.3.0"}
+  "ocamlformat-rpc-lib" {with-test & post & = version}
+  "ocp-indent"
+  "odoc-parser" {>= "1.0.0"}
+  "re" {>= "1.7.2"}
+  "stdio"
+  "uuseg" {>= "10.0.0"}
+  "uutf" {>= "1.0.1"}
+  "csexp" {>= "1.4.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
+url {
+  src:
+    "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.22.4/ocamlformat-0.22.4.tbz"
+  checksum: [
+    "sha256=eb54de2b81ac7cc2e68d81a7dc80b391a81b737fcfa3ef969ea91bdad6c9c060"
+    "sha512=2bdeb9abc5757176040f641b22c59ac2b038c3bc1c42ddf86422b80cb90278fbe8ca05d0f788be0375a632bb6584b8d165d07f9f84686c2174208a8c20324b13"
+  ]
+}
+x-commit-hash: "838ba9fa00cc27703441220b9a5d3880b17430fb"

--- a/packages/upstream/odoc-parser.1.0.0/opam
+++ b/packages/upstream/odoc-parser.1.0.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+name: "odoc-parser"
+version: "1.0.0"
+synopsis: "Parser for ocaml documentation comments"
+description: """\
+Odoc_parser is a library for parsing the contents of OCaml documentation
+comments, formatted using 'odoc' syntax, an extension of the language
+understood by ocamldoc."""
+maintainer: "Jon Ludlam <jon@recoil.org>"
+authors: "Anton Bachin <antonbachin@yahoo.com>"
+license: "ISC"
+homepage: "https://github.com/ocaml-doc/odoc-parser"
+doc: "https://ocaml-doc.github.io/odoc-parser/"
+bug-reports: "https://github.com/ocaml-doc/odoc-parser/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.02.0"}
+  "astring"
+  "result"
+  "ppx_expect" {with-test}
+  ("ocaml" {< "4.04.1" & with-test} | "sexplib0" {with-test})
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs "@install" "@runtest" {with-test}]
+]
+dev-repo: "git+https://github.com/ocaml-doc/odoc-parser.git"
+url {
+  src:
+    "https://github.com/ocaml-doc/odoc-parser/releases/download/1.0.0/odoc-parser-1.0.0.tbz"
+  checksum: [
+    "sha256=b6aa08ea71a9ebad9b2bebc4da1eda0d713cf3674e6d57d10459d934286e7aa1"
+    "sha512=b5caee3a0d288aeaa95e3f32de8e5f75f169ad2691d75f8d6c932e4fb0e6cb188813ac2d92d4076fe75b12217130e6999c46e7890cf0fa765070870f85a96d63"
+  ]
+}
+x-commit-hash: "b13ffc2f30ca20ca5bb733be4f630d46bd274fd6"


### PR DESCRIPTION
Update packages to be compatible with ocaml 4.14.

Some packages around ocamlformat need to have 2 versions to be able to work in both versions of the compilers, this affects the artifacts that generated from this version.

Because the ocamlformat version has been changed once we move to ocaml 4.14 the formatting of xapi will need to change accordingly

I would rather wait until 4.14.1 is available before merging this, it is probably a good idea to merge the upstream changes before this one as well.