### PR TITLE
ci: avoid deprecated actions in github

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -9,7 +9,9 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
 
     - name: Install opam
       run: sudo apt-get install -y opam
@@ -21,31 +23,11 @@ jobs:
       run: make archive
 
     - name: Draft Release ${{ github.ref_name }}
-      id: create_release
-      uses: actions/create-release@v1
+      run: gh release create ${{ github.ref_name }} --draft --generate-notes
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${{ github.ref_name }}
-        release_name: ${{ github.ref_name }}
-        draft: true
 
-    - name: Upload licenses.txt
-      uses: actions/upload-release-asset@v1.0.1
+    - name: Upload artifacts
+      run: gh release upload ${{ github.ref_name }} licenses.txt xs-opam-repo-${{ github.ref_name }}.tar.gz
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./licenses.txt
-        asset_name: licenses.txt
-        asset_content_type: text/plain
-
-    - name: Upload xs-opam-repo-${{ github.ref_name }}.tar.gz
-      uses: actions/upload-release-asset@v1.0.1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./xs-opam-repo-${{ github.ref_name }}.tar.gz
-        asset_name: xs-opam-repo-${{ github.ref_name }}.tar.gz
-        asset_content_type: application/gzip

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,16 +25,16 @@ jobs:
         shell: bash
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Retrieve date for cache key
         id: cache-key
-        run: echo "::set-output name=date::$(/bin/date -u "+%Y%m%d")"
+        run: echo "date=$(/bin/date -u "+%Y%m%d")" >> $GITHUB_OUTPUT
         shell: bash
 
       - name: Restore opam cache
         id: opam-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: "~/.opam"
           # invalidate cache daily, gets built daily using a scheduled job

--- a/.github/workflows/yangtze-lcm.yml
+++ b/.github/workflows/yangtze-lcm.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: 'release/yangtze/lcm'
       - name: Build the whole xs-toolstack


### PR DESCRIPTION
In particular the "official" actions to set up releases were abandoned, so the gh CLI is used instead

Signed-off-by: Pau Ruiz Safont <pau.ruizsafont@cloud.com>