### PR TITLE
xenctrl.dummy: do not rsync Xen packages we do not use

### DIFF
--- a/packages/xs/xenctrl.dummy/opam
+++ b/packages/xs/xenctrl.dummy/opam
@@ -8,8 +8,6 @@ tags: [
 build: [
   ["rsync" "-avz" "/usr/lib64/ocaml/xenctrl/" "%{lib}%/xenctrl/"]
   ["rsync" "-avz" "/usr/lib64/ocaml/xenmmap/" "%{lib}%/xenmmap/"]
-  ["rsync" "-avz" "/usr/lib64/ocaml/xenlight/" "%{lib}%/xenlight/"]
-  ["rsync" "-avz" "/usr/lib64/ocaml/xentoollog/" "%{lib}%/xentoollog/"]
   ["rsync" "-avz" "/usr/lib64/ocaml/xeneventchn/" "%{lib}%/xeneventchn/"]
 ]
 remove: [


### PR DESCRIPTION
Xen has dropped some packages such as xenlight already.

Draft, until I do a full chainbuild