### PR TITLE
vhd-format: move from upstream to xs-extra

### DIFF
--- a/packages/xs-extra/vhd-format-lwt.master/opam
+++ b/packages/xs-extra/vhd-format-lwt.master/opam
@@ -1,6 +1,5 @@
 opam-version: "2.0"
 name: "vhd-format-lwt"
-version: "0.12.3"
 synopsis: "Lwt interface to read/write VHD format data"
 description: """\
 A pure OCaml library to read and write
@@ -33,13 +32,8 @@ build: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depexts: ["linux-headers"] {os-distribution = "alpine"}
-dev-repo: "git+https://github.com/mirage/ocaml-vhd.git"
+dev-repo: "git+https://github.com/xapi-project/xen-api.git"
 url {
   src:
-    "https://github.com/mirage/ocaml-vhd/releases/download/v0.12.3/vhd-format-0.12.3.tbz"
-  checksum: [
-    "sha256=e3da58f79172f7c55d8b07cea100358771248b435baf5fbe941e61e6d0840730"
-    "sha512=3af8d9f618266c5bd9c65e1b81c97c6e68c07ab84b8031dbef691ac7775fe7ea308be995dfdba8a785f404aeb44a3e094c78861f1e9f8d8321a1110c1da64fd5"
-  ]
+    "https://github.com/xapi-project/xen-api/archive/master.tar.gz"
 }
-x-commit-hash: "6f3f75bc881c6f22117e01aa8520fa70564fde42"

--- a/packages/xs-extra/vhd-format.master/opam
+++ b/packages/xs-extra/vhd-format.master/opam
@@ -1,6 +1,5 @@
 opam-version: "2.0"
 name: "vhd-format"
-version: "0.12.3"
 synopsis: "Pure OCaml library to read/write VHD format data"
 description: """\
 A pure OCaml library to read and write
@@ -28,13 +27,8 @@ depends: [
 available: os = "linux" | os = "macos"
 build: ["dune" "build" "-p" name "-j" jobs]
 depexts: ["linux-headers"] {os-distribution = "alpine"}
-dev-repo: "git+https://github.com/mirage/ocaml-vhd.git"
+dev-repo: "git+https://github.com/xapi-project/xen-api.git"
 url {
   src:
-    "https://github.com/mirage/ocaml-vhd/releases/download/v0.12.3/vhd-format-0.12.3.tbz"
-  checksum: [
-    "sha256=e3da58f79172f7c55d8b07cea100358771248b435baf5fbe941e61e6d0840730"
-    "sha512=3af8d9f618266c5bd9c65e1b81c97c6e68c07ab84b8031dbef691ac7775fe7ea308be995dfdba8a785f404aeb44a3e094c78861f1e9f8d8321a1110c1da64fd5"
-  ]
+    "https://github.com/xapi-project/xen-api/archive/master.tar.gz"
 }
-x-commit-hash: "6f3f75bc881c6f22117e01aa8520fa70564fde42"


### PR DESCRIPTION
Now it's vendored in the xapi repository, this should fix xs-opam's CI