### PR TITLE
packages/upstream/rpclib*/opam: dev-repo must use github https

### DIFF
--- a/packages/upstream/batteries.3.6.0/opam
+++ b/packages/upstream/batteries.3.6.0/opam
@@ -28,7 +28,7 @@ build: [
 ]
 run-test: [make "test"]
 install: [make "install"]
-dev-repo: "git://github.com/ocaml-batteries-team/batteries-included.git"
+dev-repo: "https://github.com/ocaml-batteries-team/batteries-included.git"
 url {
   src: "https://github.com/ocaml-batteries-team/batteries-included/archive/refs/tags/v3.6.0.tar.gz"
   checksum: [

--- a/packages/upstream/ppx_deriving_rpc.9.0.0/opam
+++ b/packages/upstream/ppx_deriving_rpc.9.0.0/opam
@@ -30,7 +30,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
-dev-repo: "git://github.com/mirage/ocaml-rpc"
+dev-repo: "https://github.com/mirage/ocaml-rpc.git"
 url {
   src:
     "https://github.com/mirage/ocaml-rpc/releases/download/9.0.0/rpclib-9.0.0.tbz"

--- a/packages/upstream/rpclib-async.9.0.0/opam
+++ b/packages/upstream/rpclib-async.9.0.0/opam
@@ -29,7 +29,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
-dev-repo: "git://github.com/mirage/ocaml-rpc"
+dev-repo: "https://github.com/mirage/ocaml-rpc.git"
 url {
   src:
     "https://github.com/mirage/ocaml-rpc/releases/download/9.0.0/rpclib-9.0.0.tbz"

--- a/packages/upstream/rpclib-lwt.9.0.0/opam
+++ b/packages/upstream/rpclib-lwt.9.0.0/opam
@@ -30,7 +30,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
-dev-repo: "git://github.com/mirage/ocaml-rpc"
+dev-repo: "https://github.com/mirage/ocaml-rpc.git"
 url {
   src:
     "https://github.com/mirage/ocaml-rpc/releases/download/9.0.0/rpclib-9.0.0.tbz"

--- a/packages/upstream/rpclib.9.0.0/opam
+++ b/packages/upstream/rpclib.9.0.0/opam
@@ -35,7 +35,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
-dev-repo: "git://github.com/mirage/ocaml-rpc"
+dev-repo: "https://github.com/mirage/ocaml-rpc.git"
 url {
   src:
     "https://github.com/mirage/ocaml-rpc/releases/download/9.0.0/rpclib-9.0.0.tbz"

--- a/packages/xs-extra/forkexec.master/opam
+++ b/packages/xs-extra/forkexec.master/opam
@@ -3,7 +3,7 @@ maintainer: "xen-api@lists.xen.org"
 authors: "xen-api@lists.xen.org"
 homepage: "https://github.com/xapi-project/"
 bug-reports: "https://github.com/xapi-project/xen-api/issues"
-dev-repo: "git://github.com/xapi-project/xen-api"
+dev-repo: "https://github.com/xapi-project/xen-api.git"
 tags: [ "org:xapi-project" ]
 
 build: [[ "dune" "build" "-p" name "-j" jobs ]]

--- a/packages/xs-extra/message-switch-async.master/opam
+++ b/packages/xs-extra/message-switch-async.master/opam
@@ -4,7 +4,7 @@ maintainer: "xen-api@lists.xen.org"
 authors: [ "xen-api@lists.xen.org" ]
 homepage: "https://github.com/xapi-project/xen-api"
 bug-reports: "https://github.com/xapi-project/xen-api/issues"
-dev-repo: "git://github.com/xapi-project/xen-api"
+dev-repo: "https://github.com/xapi-project/xen-api.git"
 tags: [ "org:xapi-project" ]
 build: [
   ["./configure" "--prefix" "%{prefix}%"]

--- a/packages/xs-extra/message-switch-cli.master/opam
+++ b/packages/xs-extra/message-switch-cli.master/opam
@@ -4,7 +4,7 @@ maintainer: "xen-api@lists.xen.org"
 authors: [ "xen-api@lists.xen.org" ]
 homepage: "https://github.com/xapi-project/xen-api"
 bug-reports: "https://github.com/xapi-project/xen-api/issues"
-dev-repo: "git://github.com/xapi-project/xen-api"
+dev-repo: "https://github.com/xapi-project/xen-api.git"
 tags: [ "org:xapi-project" ]
 build: [
   ["./configure" "--prefix" "%{prefix}%"]

--- a/packages/xs-extra/message-switch-core.master/opam
+++ b/packages/xs-extra/message-switch-core.master/opam
@@ -4,7 +4,7 @@ maintainer: "xen-api@lists.xen.org"
 authors: [ "xen-api@lists.xen.org" ]
 homepage: "https://github.com/xapi-project/xen-api"
 bug-reports: "https://github.com/xapi-project/xen-api/issues"
-dev-repo: "git://github.com/xapi-project/xen-api"
+dev-repo: "https://github.com/xapi-project/xen-api.git"
 tags: [ "org:xapi-project" ]
 build: [
   ["./configure" "--prefix" "%{prefix}%"]

--- a/packages/xs-extra/message-switch-lwt.master/opam
+++ b/packages/xs-extra/message-switch-lwt.master/opam
@@ -4,7 +4,7 @@ maintainer: "xen-api@lists.xen.org"
 authors: [ "xen-api@lists.xen.org" ]
 homepage: "https://github.com/xapi-project/xen-api"
 bug-reports: "https://github.com/xapi-project/xen-api/issues"
-dev-repo: "git://github.com/xapi-project/xen-api"
+dev-repo: "https://github.com/xapi-project/xen-api.git"
 tags: [ "org:xapi-project" ]
 build: [
   ["./configure" "--prefix" "%{prefix}%"]

--- a/packages/xs-extra/message-switch-unix.master/opam
+++ b/packages/xs-extra/message-switch-unix.master/opam
@@ -4,7 +4,7 @@ maintainer: "xen-api@lists.xen.org"
 authors: [ "xen-api@lists.xen.org" ]
 homepage: "https://github.com/xapi-project/xen-api"
 bug-reports: "https://github.com/xapi-project/xen-api/issues"
-dev-repo: "git://github.com/xapi-project/xen-api"
+dev-repo: "https://github.com/xapi-project/xen-api.git"
 tags: [ "org:xapi-project" ]
 build: [
   ["./configure" "--prefix" "%{prefix}%"]

--- a/packages/xs-extra/message-switch.master/opam
+++ b/packages/xs-extra/message-switch.master/opam
@@ -4,7 +4,7 @@ maintainer: "xen-api@lists.xen.org"
 authors: [ "xen-api@lists.xen.org" ]
 homepage: "https://github.com/xapi-project/xen-api"
 bug-reports: "https://github.com/xapi-project/xen-api/issues"
-dev-repo: "git://github.com/xapi-project/xen-api"
+dev-repo: "https://github.com/xapi-project/xen-api.git"
 tags: [ "org:xapi-project" ]
 build: [
   ["./configure" "--prefix" "%{prefix}%"]

--- a/packages/xs-extra/rrdd-plugin.master/opam
+++ b/packages/xs-extra/rrdd-plugin.master/opam
@@ -3,7 +3,7 @@ maintainer: "xen-api@lists.xen.org"
 authors: "xen-api@lists.xen.org"
 homepage: "https://xapi-project.github.io/"
 bug-reports: "https://github.com/xapi-project/xen-api/issues"
-dev-repo: "git://github.com/xapi-project/xen-api.git"
+dev-repo: "https://github.com/xapi-project/xen-api.git"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}

--- a/packages/xs-extra/rrdd-plugins.master/opam
+++ b/packages/xs-extra/rrdd-plugins.master/opam
@@ -5,7 +5,7 @@ authors: [ "xs-devel@lists.xenserver.org" ]
 license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 homepage: "https://github.com/xapi-project/xen-api"
 bug-reports: "https://github.com/xapi-project/xen-api/issues"
-dev-repo: "git://github.com/xapi-project/xen-api"
+dev-repo: "https://github.com/xapi-project/xen-api.git"
 build: [[ "dune" "build" "-p" name "-j" jobs ]]
 synopsis: "Plugins registering to the RRD daemon and exposing various metrics"
 depends: [

--- a/packages/xs-extra/xapi-forkexecd.master/opam
+++ b/packages/xs-extra/xapi-forkexecd.master/opam
@@ -3,7 +3,7 @@ maintainer: "xen-api@lists.xen.org"
 authors: "xen-api@lists.xen.org"
 homepage: "https://github.com/xapi-project/"
 bug-reports: "https://github.com/xapi-project/xen-api/issues"
-dev-repo: "git://github.com/xapi-project/xen-api"
+dev-repo: "https://github.com/xapi-project/xen-api.git"
 tags: [ "org:xapi-project" ]
 
 build: [

--- a/packages/xs-extra/xapi-idl.master/opam
+++ b/packages/xs-extra/xapi-idl.master/opam
@@ -2,7 +2,7 @@ opam-version: "2.0"
 authors: "Dave Scott"
 homepage: "https://github.com/xapi-project/xcp-idl"
 bug-reports: "https://github.com/xapi-project/xcp-idl/issues"
-dev-repo: "git://github.com/xapi-project/xcp-idl"
+dev-repo: "https://github.com/xapi-project/xcp-idl.git"
 maintainer: "xen-api@lists.xen.org"
 tags: [ "org:xapi-project" ]
 build: [["dune" "build" "-p" name "-j" jobs]]

--- a/packages/xs-extra/xapi-rrdd-plugin.master/opam
+++ b/packages/xs-extra/xapi-rrdd-plugin.master/opam
@@ -3,7 +3,7 @@ maintainer: "xen-api@lists.xen.org"
 authors: "xen-api@lists.xen.org"
 homepage: "https://xapi-project.github.io/"
 bug-reports: "https://github.com/xapi-project/xen-api/issues"
-dev-repo: "git://github.com/xapi-project/xen-api.git"
+dev-repo: "https://github.com/xapi-project/xen-api.git"
 depends: ["ocaml" "rrdd-plugin"]
 synopsis: "A plugin library for the xapi performance monitoring daemon"
 description: """

--- a/packages/xs-extra/xapi-squeezed.master/opam
+++ b/packages/xs-extra/xapi-squeezed.master/opam
@@ -3,7 +3,7 @@ author: "dave.scott@eu.citrix.com"
 maintainer: "xen-api@lists.xen.org"
 homepage: "https://github.com/xapi-project/xen-api"
 bug-reports: "https://github.com/xapi-project/xen-api/issues"
-dev-repo: "git://github.com/xapi-project/xen-api.git"
+dev-repo: "https://github.com/xapi-project/xen-api.git"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "build" "-p" name "-j" jobs "@runtest"] {with-test}

--- a/packages/xs-extra/xapi-storage-script.master/opam
+++ b/packages/xs-extra/xapi-storage-script.master/opam
@@ -5,7 +5,7 @@ authors: [ "xen-api@lists.xen.org" ]
 license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 homepage: "https://github.com/xapi-project/xen-api"
 bug-reports: "https://github.com/xapi-project/xen-api/issues"
-dev-repo: "git://github.com/xapi-project/xen-api"
+dev-repo: "https://github.com/xapi-project/xen-api.git"
 tags: [ "org:xapi-project" ]
 build: [[ "dune" "build" "-p" name "-j" jobs ]]
 depends: [

--- a/packages/xs-extra/xapi-storage.master/opam
+++ b/packages/xs-extra/xapi-storage.master/opam
@@ -4,7 +4,7 @@ maintainer: "xen-api@lists.xen.org"
 authors: "xen-api@lists.xen.org"
 homepage: "https://xapi-project.github.io/"
 bug-reports: "https://github.com/xapi-project/xen-api/issues"
-dev-repo: "git://github.com/xapi-project/xen-api.git"
+dev-repo: "https://github.com/xapi-project/xen-api.git"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]

--- a/packages/xs/polly.0.3.0/opam
+++ b/packages/xs/polly.0.3.0/opam
@@ -20,7 +20,7 @@ depends: [
   "conf-linux-libc-dev"
 ]
 build: ["dune" "build" "-p" name "-j" jobs "@install"]
-dev-repo: "git://github.com/lindig/polly.git"
+dev-repo: "https://github.com/lindig/polly.git"
 url {
   src: "https://github.com/lindig/polly/archive/refs/tags/0.3.0.tar.gz"
   checksum: "sha256=957abbaac82bf9f00aa23c015c5be0d8d2aa79151b8f3d5344bfb26c3c82f4c4"

--- a/packages/xs/xapi-backtrace.0.7/opam
+++ b/packages/xs/xapi-backtrace.0.7/opam
@@ -3,7 +3,7 @@ maintainer: "xen-api@lists.xen.org"
 authors: "xen-api@lists.xen.org"
 homepage: "https://github.com/xapi-project/backtrace"
 bug-reports: "https://github.com/xapi-project/backtrace/issues"
-dev-repo: "git://github.com/xapi-project/backtrace.git"
+dev-repo: "https://github.com/xapi-project/backtrace.git"
 tags: [ "org:xapi-project" ]
 license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 

--- a/packages/xs/xapi-test-utils.1.4.0/opam
+++ b/packages/xs/xapi-test-utils.1.4.0/opam
@@ -3,7 +3,7 @@ maintainer: "rob.hoes@citrix.com"
 authors: "xen-api@lists.xen.org"
 homepage: "https://xapi-project.github.io/"
 bug-reports: "https://github.com/xapi-project/xapi-test-utils/issues"
-dev-repo: "git://github.com/xapi-project/xapi-test-utils.git"
+dev-repo: "https://github.com/xapi-project/xapi-test-utils.git"
 license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 build: [[ "dune" "build" "-p" name "-j" jobs ]]
 depends: [


### PR DESCRIPTION
Fix `opam source --dev rpclib -vv` to use the github https URL instead of the git:// protocol which was discontinued by github.

Co-authored-by: @edwintorok 