### PR TITLE
Revert "ci: update setup-ocaml to v2"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,28 +14,48 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ocaml-compiler: ["4.14.1"]
+        ocaml-version: ["4.14.1"]
         experimental: [false]
           # include:
-          # - ocaml-compiler: "5.2.0"
+          # - ocaml-version: "5.2.0"
           #   experimental: true
 
     continue-on-error: ${{ matrix.experimental }}
+    env:
+      OCAML_VERSION: ${{ matrix.ocaml-version }}
+
     steps:
       - name: Update apt cache
         run: sudo apt-get update
+        shell: bash
 
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Use ocaml
-        uses: ocaml/setup-ocaml@v2
+      - name: Retrieve date for cache key
+        id: cache-key
+        run: echo "date=$(/bin/date -u "+%Y%m%d")" >> $GITHUB_OUTPUT
+        shell: bash
+
+      - name: Restore opam cache
+        id: opam-cache
+        uses: actions/cache@v3
         with:
-          ocaml-compiler: ${{ matrix.ocaml-compiler }}
-          opam-repositories: |
-            xs-opam: "."
-          opam-pin: false
-          dune-cache: true
+          path: "~/.opam"
+          # invalidate cache daily, gets built daily using a scheduled job
+          key: ${{ steps.cache-key.outputs.date }}-${{ matrix.ocaml-version }}
+
+      - name: Use ocaml
+        uses: avsm/setup-ocaml@v1
+        with:
+          ocaml-version: ${{ matrix.ocaml-version }}
+          opam-repository: "."
+
+      - name: Upgrade existing packages
+        run: |
+          opam update
+          opam depext -vv -y xs-toolstack
+          opam upgrade
 
       - name: Check whether there are packages with more than a version
         run: tools/no-duplicates-check.bash
@@ -47,11 +67,8 @@ jobs:
         run: tools/license-check.sh
 
       - name: Build xs-toolstack, test its dependencies
-        # opam install may ignore installing depexts sometimes
-        # OPAMCOLOR is set to "always" by default and it breaks piping
         run: |
-          OPAMERRLOGLEN=10000 OPAMCOLOR=NEVER opam list -s --required-by xs-toolstack | xargs opam depext -tu
-          OPAMERRLOGLEN=10000 OPAMCOLOR=NEVER opam list -s --required-by xs-toolstack | xargs opam install -t
+          OPAMERRLOGLEN=10000 opam list -s --required-by xs-toolstack | xargs opam install -t
 
       - name: Uninstall unversioned packages
         # This should purge them from the cache, unversioned package have


### PR DESCRIPTION
With v2 the runners consistently get out of disk space and make the ci fail

This reverts commit 6ffdaf74d2de345157f0366771f0fe755995defc.

The out-of-disk issue doesn't happen for yangtze, probably because of the amount of libraries that need to be compiled. I'll try again with v2 once the work for dropping async and core libraries is done