### PR TITLE
github: update image and free space

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Free space
+        run: sudo rm -rf /usr/local/lib/android
+
       - name: Retrieve date for cache key
         id: cache-key
         run: echo "date=$(/bin/date -u "+%Y%m%d")" >> $GITHUB_OUTPUT

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build:
     name: Build and test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
On the last week CI runs have started to fail consistently because they run out of space. The default runner images have way too many files that are useless for building ocaml.

Start with the removal of android tools, we'll see if it's enough, I don't want to remove all tools because it can also take a couple of minutes to do so.