### PR TITLE
xs-extra: add newly added dependency for xapi-tracing

### DIFF
--- a/packages/xs-extra/xapi-tracing.master/opam
+++ b/packages/xs-extra/xapi-tracing.master/opam
@@ -17,6 +17,7 @@ depends: [
   "xapi-open-uri"
   "xapi-stdext-threads"
   "xapi-stdext-unix"
+  "zstd"
 ]
 synopsis: "Library required by xapi"
 description: """


### PR DESCRIPTION
This fixes the CI builds