### PR TITLE
upstream: use python3 in all centos distributions

### DIFF
--- a/packages/upstream/conf-python-3.9.0.0/opam
+++ b/packages/upstream/conf-python-3.9.0.0/opam
@@ -18,7 +18,7 @@ depexts: [
   ["python3"] {os-family = "debian"}
   ["python3"] {os-distribution = "nixos"}
   ["python3"] {os-distribution = "alpine"}
-  ["epel-release" "python39"] {os-distribution = "centos"}
+  ["python3"] {os-distribution = "centos"}
   ["python3"] {os-distribution = "fedora"}
   ["python3"] {os-distribution = "ol"}
   ["python"] {os-distribution = "arch"}


### PR DESCRIPTION
Forcing 3.9 broke centos 7 as only 3.6 is available