### PR TITLE
upstream: non-breaking dependencies

### DIFF
--- a/.github/unused-upstream.txt
+++ b/.github/unused-upstream.txt
@@ -7,6 +7,7 @@ ocamlformat
 ocamlformat-lib
 ocp-indent
 syslog-message
+trace
 tyre
 tyxml
 uuseg

--- a/packages/upstream-extra/chrome-trace.3.15.2/opam
+++ b/packages/upstream-extra/chrome-trace.3.15.2/opam
@@ -1,9 +1,9 @@
 opam-version: "2.0"
-name: "xdg"
-version: "3.14.0"
-synopsis: "XDG Base Directory Specification"
+name: "chrome-trace"
+version: "3.15.2"
+synopsis: "Chrome trace event generation library"
 description:
-  "https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html"
+  "This library offers no backwards compatibility guarantees. Use at your own risk."
 maintainer: "Jane Street Group, LLC <opensource@janestreet.com>"
 authors: "Jane Street Group, LLC <opensource@janestreet.com>"
 license: "MIT"
@@ -12,7 +12,7 @@ doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
   "dune" {>= "3.12"}
-  "ocaml" {>= "4.08"}
+  "ocaml" {>= "4.08.0"}
   "odoc" {with-doc}
 ]
 build: [
@@ -24,10 +24,10 @@ build: [
 dev-repo: "git+https://github.com/ocaml/dune.git"
 url {
   src:
-    "https://github.com/ocaml/dune/releases/download/3.14.0/dune-3.14.0.tbz"
+    "https://github.com/ocaml/dune/releases/download/3.15.2/dune-3.15.2.tbz"
   checksum: [
-    "sha256=f4d09d89162621fdff424c253fa50c4920d2179fb5b3d1debab7bbe97c68b2fc"
-    "sha512=f5ead1a9a0cc26e00a762e83e107b47c3c3fe9b44d9e505547c385c7938208d4fdcc91a8099512e76ea4a426f3543445b4d75ef0b621dc7dbfdcbb615bc0b999"
+    "sha256=f959980542ca85909b3f3f8e9be65c2b8a375f3a4e3bd83c7ad7a07f2e077933"
+    "sha512=d752b8c09130cf3d564b3a524e3148783b581daa3f9a61d0f52bf4d6995ef73258e71877dbfd8b7516f9a4bac5ad973e80f4fed596df9446e704acc724aac55e"
   ]
 }
-x-commit-hash: "73250f00372d3f28a25963ded6138728f4202663"
+x-commit-hash: "c28817c416ac0b381f6a6938236419ab5d86d6e1"

--- a/packages/upstream-extra/conf-jq.1/opam
+++ b/packages/upstream-extra/conf-jq.1/opam
@@ -13,6 +13,7 @@ flags: conf
 build: ["jq" "--version"]
 depexts: [
   ["jq"] {os-family = "debian"}
+  ["jq"] {os-family = "ubuntu"}
   ["jq"] {os-distribution = "fedora"}
   ["jq"] {os-distribution = "rhel"}
   ["epel-release" "jq"] {os-distribution = "centos"}

--- a/packages/upstream-extra/conf-ncurses.1/opam
+++ b/packages/upstream-extra/conf-ncurses.1/opam
@@ -23,6 +23,7 @@ build:
      os != "openbsd"}
 depexts: [
   ["ncurses-dev"] {os-family = "debian"}
+  ["lib64ncurses-dev"] {os-family = "ubuntu"}
   ["ncurses"] {os-distribution = "nixos"}
   ["ncurses-dev"] {os-distribution = "alpine"}
   ["ncurses-devel"] {os-distribution = "fedora"}
@@ -32,4 +33,5 @@ depexts: [
   ["ncurses-devel"] {os-family = "suse"}
   ["ncurses"] {os-distribution = "arch"}
   ["ncurses"] {os = "win32" & os-distribution = "cygwinports"}
+  ["ncurses"] {os = "freebsd"}
 ]

--- a/packages/upstream-extra/conf-ruby.1.0.0/opam
+++ b/packages/upstream-extra/conf-ruby.1.0.0/opam
@@ -16,9 +16,11 @@ depexts: [
   ["ruby"] {os-distribution = "arch"}
   ["ruby"] {os-distribution = "centos"}
   ["ruby"] {os-family = "debian"}
+  ["ruby"] {os-family = "ubuntu"}
   ["ruby"] {os-distribution = "fedora"}
   ["dev-lang/ruby"] {os-distribution = "gentoo"}
   ["ruby"] {os-distribution = "homebrew" & os = "macos"}
+  ["ruby"] {os = "freebsd"}
   ["ruby"] {os = "netbsd"}
   ["ruby"] {os-distribution = "nixos"}
   ["ruby"] {os = "openbsd"}

--- a/packages/upstream-extra/conf-xen.1/opam
+++ b/packages/upstream-extra/conf-xen.1/opam
@@ -15,6 +15,7 @@ build: ["sh" "-exc" "cc -c $CFLAGS -I/usr/local/include test.c"]
 depexts: [
   ["xen-dev"] {os-distribution = "alpine"}
   ["libxen-dev"] {os-family = "debian"}
+  ["libxen-dev"] {os-family = "ubuntu"}
   ["xen-devel"] {os-distribution = "centos"}
   ["xen-devel"] {os-distribution = "fedora"}
   ["xen-devel"] {os-distribution = "rhel"}

--- a/packages/upstream-extra/dot-merlin-reader.4.9/opam
+++ b/packages/upstream-extra/dot-merlin-reader.4.9/opam
@@ -13,7 +13,7 @@ bug-reports: "https://github.com/ocaml/merlin/issues"
 depends: [
   "ocaml" {>= "4.08" & < "6.0"}
   "dune" {>= "2.9.0"}
-  "merlin-lib" {>= "4.9"}
+  "merlin-lib" {>= "4.9" & < "4.14-502"}
   "ocamlfind" {>= "1.6.0"}
 ]
 build: [

--- a/packages/upstream-extra/dune-rpc.3.15.2/opam
+++ b/packages/upstream-extra/dune-rpc.3.15.2/opam
@@ -1,8 +1,8 @@
 opam-version: "2.0"
-name: "ordering"
-version: "3.14.0"
-synopsis: "Element ordering"
-description: "Element ordering"
+name: "dune-rpc"
+version: "3.15.2"
+synopsis: "Communicate with dune using rpc"
+description: "Library to connect and control a running dune instance"
 maintainer: "Jane Street Group, LLC <opensource@janestreet.com>"
 authors: "Jane Street Group, LLC <opensource@janestreet.com>"
 license: "MIT"
@@ -11,7 +11,12 @@ doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
   "dune" {>= "3.12"}
-  "ocaml" {>= "4.08.0"}
+  "csexp"
+  "ordering"
+  "dyn"
+  "xdg"
+  "stdune" {= version}
+  "pp" {>= "1.1.0"}
   "odoc" {with-doc}
 ]
 build: [
@@ -23,10 +28,10 @@ build: [
 dev-repo: "git+https://github.com/ocaml/dune.git"
 url {
   src:
-    "https://github.com/ocaml/dune/releases/download/3.14.0/dune-3.14.0.tbz"
+    "https://github.com/ocaml/dune/releases/download/3.15.2/dune-3.15.2.tbz"
   checksum: [
-    "sha256=f4d09d89162621fdff424c253fa50c4920d2179fb5b3d1debab7bbe97c68b2fc"
-    "sha512=f5ead1a9a0cc26e00a762e83e107b47c3c3fe9b44d9e505547c385c7938208d4fdcc91a8099512e76ea4a426f3543445b4d75ef0b621dc7dbfdcbb615bc0b999"
+    "sha256=f959980542ca85909b3f3f8e9be65c2b8a375f3a4e3bd83c7ad7a07f2e077933"
+    "sha512=d752b8c09130cf3d564b3a524e3148783b581daa3f9a61d0f52bf4d6995ef73258e71877dbfd8b7516f9a4bac5ad973e80f4fed596df9446e704acc724aac55e"
   ]
 }
-x-commit-hash: "73250f00372d3f28a25963ded6138728f4202663"
+x-commit-hash: "c28817c416ac0b381f6a6938236419ab5d86d6e1"

--- a/packages/upstream-extra/ocamlc-loc.3.15.2/opam
+++ b/packages/upstream-extra/ocamlc-loc.3.15.2/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
-name: "stdune"
-version: "3.14.0"
-synopsis: "Dune's unstable standard library"
+name: "ocamlc-loc"
+version: "3.15.2"
+synopsis: "Parse ocaml compiler output into structured form"
 description:
   "This library offers no backwards compatibility guarantees. Use at your own risk."
 maintainer: "Jane Street Group, LLC <opensource@janestreet.com>"
@@ -13,12 +13,11 @@ bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
   "dune" {>= "3.12"}
   "ocaml" {>= "4.08.0"}
-  "base-unix"
   "dyn" {= version}
-  "ordering" {= version}
-  "pp" {>= "1.2.0"}
-  "csexp" {>= "1.5.0"}
   "odoc" {with-doc}
+]
+conflicts: [
+  "ocaml-lsp-server" {< "1.15.0"}
 ]
 build: [
   ["dune" "subst"] {dev}
@@ -29,10 +28,10 @@ build: [
 dev-repo: "git+https://github.com/ocaml/dune.git"
 url {
   src:
-    "https://github.com/ocaml/dune/releases/download/3.14.0/dune-3.14.0.tbz"
+    "https://github.com/ocaml/dune/releases/download/3.15.2/dune-3.15.2.tbz"
   checksum: [
-    "sha256=f4d09d89162621fdff424c253fa50c4920d2179fb5b3d1debab7bbe97c68b2fc"
-    "sha512=f5ead1a9a0cc26e00a762e83e107b47c3c3fe9b44d9e505547c385c7938208d4fdcc91a8099512e76ea4a426f3543445b4d75ef0b621dc7dbfdcbb615bc0b999"
+    "sha256=f959980542ca85909b3f3f8e9be65c2b8a375f3a4e3bd83c7ad7a07f2e077933"
+    "sha512=d752b8c09130cf3d564b3a524e3148783b581daa3f9a61d0f52bf4d6995ef73258e71877dbfd8b7516f9a4bac5ad973e80f4fed596df9446e704acc724aac55e"
   ]
 }
-x-commit-hash: "73250f00372d3f28a25963ded6138728f4202663"
+x-commit-hash: "c28817c416ac0b381f6a6938236419ab5d86d6e1"

--- a/packages/upstream-extra/ocamlformat-rpc-lib.0.26.2/opam
+++ b/packages/upstream-extra/ocamlformat-rpc-lib.0.26.2/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "ocamlformat-rpc-lib"
-version: "0.26.1"
+version: "0.26.2"
 synopsis: "Auto-formatter for OCaml code (RPC mode)"
 description:
   "OCamlFormat is a tool to automatically format OCaml code in a uniform style. This package defines a RPC interface to OCamlFormat"
@@ -42,10 +42,10 @@ build: [
 dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
 url {
   src:
-    "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.26.1/ocamlformat-0.26.1.tbz"
+    "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.26.2/ocamlformat-0.26.2.tbz"
   checksum: [
-    "sha256=da006e427f15b9ec612fb808d446599bd9b7c3ee25abeb3d555747a70d74c6d7"
-    "sha512=b7413f8dc47ba3a2372e89d59cae54f9a602ab81e31cd14ed986a831111080b79a5a3cc45dac04d8ffae5054c35bf29fe9559f145c76c87a30e191ed5400942a"
+    "sha256=2e4f596bf7aa367a844fe83ba0f6b0bf14b2a65179ddc082363fe9793d0375c5"
+    "sha512=b03d57462e65b11aa9f78dd5c4548251e8d1c5a1c9662f7502bdb10472aeb9df33c1d407350767a5223fbff9c01d53de85bafacd0274b49abc4b43701b159bee"
   ]
 }
-x-commit-hash: "6734dfc1992eb782f0a936ce3cd7c78b7c1d39d3"
+x-commit-hash: "f5727b32127730a2722f86c7119eb6d8f884e26d"

--- a/packages/upstream-extra/odoc-parser.2.4.2/opam
+++ b/packages/upstream-extra/odoc-parser.2.4.2/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "odoc-parser"
-version: "2.4.1"
+version: "2.4.2"
 synopsis: "Parser for ocaml documentation comments"
 description: """\
 Odoc_parser is a library for parsing the contents of OCaml documentation
@@ -36,10 +36,10 @@ build: [
 ]
 dev-repo: "git+https://github.com/ocaml/odoc.git"
 url {
-  src: "https://github.com/ocaml/odoc/releases/download/2.4.1/odoc-2.4.1.tbz"
+  src: "https://github.com/ocaml/odoc/releases/download/2.4.2/odoc-2.4.2.tbz"
   checksum: [
-    "sha256=b814a0b9020b503eb67f17d1d9a969d052b63d8cdc7cdfa5fb793b137558cedb"
-    "sha512=8ed2ed6ef705c00a2c90b7c57e7e5c747247e3406f1b7415a46db7cbd19d02678db40be761984d627f4fa2d9b38f696c77d8b5d40108e12563e101d07949821c"
+    "sha256=563cfdbb26ec8a30e737a9cf285a06e0bbae953f48e25bbb0f69f7a99c2ba40b"
+    "sha512=8d48c99e0c253791177dd65287ce5cee47e7c6805e33f3ae0cf6c8e7d349128f26eebbe36459c31429c11519ad5979dbe36fbcb9403a5fde199a69976a3fb3a6"
   ]
 }
-x-commit-hash: "0e671097a35ef938ea390a6bb894f25d8dc847a8"
+x-commit-hash: "85644b01ca86d1061766908bba3653ced2c15ce4"

--- a/packages/upstream-extra/odoc.2.4.2/opam
+++ b/packages/upstream-extra/odoc.2.4.2/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "odoc"
-version: "2.4.1"
+version: "2.4.2"
 synopsis: "OCaml Documentation Generator"
 description: """\
 **odoc** is a powerful and flexible documentation generator for OCaml. It reads *doc comments*, demarcated by `(** ... *)`, and transforms them into a variety of output formats, including HTML, LaTeX, and man pages.
@@ -39,7 +39,7 @@ depends: [
   "cppo" {build & >= "1.1.0"}
   "dune" {>= "3.7.0"}
   "fpath"
-  "ocaml" {>= "4.02.0" & < "5.2"}
+  "ocaml" {>= "4.02.0"}
   "result"
   "tyxml" {>= "4.4.0"}
   "fmt"
@@ -49,7 +49,7 @@ depends: [
   "conf-jq" {with-test}
   "ppx_expect" {with-test}
   "bos" {with-test}
-  "crunch" {> "1.1.0"}
+  "crunch" {> "2.0.0"}
   ("ocaml" {< "4.07.0" & with-test} | "bisect_ppx" {with-test & > "2.5.0"})
 ]
 build: [
@@ -68,10 +68,10 @@ build: [
 ]
 dev-repo: "git+https://github.com/ocaml/odoc.git"
 url {
-  src: "https://github.com/ocaml/odoc/releases/download/2.4.1/odoc-2.4.1.tbz"
+  src: "https://github.com/ocaml/odoc/releases/download/2.4.2/odoc-2.4.2.tbz"
   checksum: [
-    "sha256=b814a0b9020b503eb67f17d1d9a969d052b63d8cdc7cdfa5fb793b137558cedb"
-    "sha512=8ed2ed6ef705c00a2c90b7c57e7e5c747247e3406f1b7415a46db7cbd19d02678db40be761984d627f4fa2d9b38f696c77d8b5d40108e12563e101d07949821c"
+    "sha256=563cfdbb26ec8a30e737a9cf285a06e0bbae953f48e25bbb0f69f7a99c2ba40b"
+    "sha512=8d48c99e0c253791177dd65287ce5cee47e7c6805e33f3ae0cf6c8e7d349128f26eebbe36459c31429c11519ad5979dbe36fbcb9403a5fde199a69976a3fb3a6"
   ]
 }
-x-commit-hash: "0e671097a35ef938ea390a6bb894f25d8dc847a8"
+x-commit-hash: "85644b01ca86d1061766908bba3653ced2c15ce4"

--- a/packages/upstream-extra/qcheck-ounit.0.21.3/opam
+++ b/packages/upstream-extra/qcheck-ounit.0.21.3/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "qcheck-ounit"
-version: "0.21.2"
+version: "0.21.3"
 synopsis: "OUnit backend for qcheck"
 maintainer: "simon.cruanes.2007@m4x.org"
 authors: "the qcheck contributors"
@@ -11,7 +11,6 @@ doc: "http://c-cube.github.io/qcheck/"
 bug-reports: "https://github.com/c-cube/qcheck/issues"
 depends: [
   "dune" {>= "2.8.0"}
-  "base-bytes"
   "base-unix"
   "qcheck-core" {= version}
   "ounit2"
@@ -25,9 +24,9 @@ build: [
 ]
 dev-repo: "git+https://github.com/c-cube/qcheck.git"
 url {
-  src: "https://github.com/c-cube/qcheck/archive/v0.21.2.tar.gz"
+  src: "https://github.com/c-cube/qcheck/archive/v0.21.3.tar.gz"
   checksum: [
-    "md5=b8e3728fc1b534ee01e3c2b7e2b30bb3"
-    "sha512=67ff77a66ccf046dfede9123a322002f232a0a65b8ce1890795a4a4ba247bc5413f988e7cfd53412418036c2b907e4cbcd7dcd39d7f1fd2481aee60107b075cc"
+    "md5=8930042156873aa8dfa433d7c1bf8463"
+    "sha512=89d8a8a1990cfa8cd839e732f4cc89d68811ae0cc04732668e1e2691e1eb6e3c525f75936bdb261aebdaa3a8845eb717128b0bf21884bbda80d64ba957d2e6e1"
   ]
 }

--- a/packages/upstream-extra/qcheck.0.21.3/opam
+++ b/packages/upstream-extra/qcheck.0.21.3/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
-name: "qcheck-core"
-version: "0.21.2"
-synopsis: "Core qcheck library"
+name: "qcheck"
+version: "0.21.3"
+synopsis: "Compatibility package for qcheck"
 maintainer: "simon.cruanes.2007@m4x.org"
 authors: "the qcheck contributors"
 license: "BSD-2-Clause"
@@ -11,8 +11,9 @@ doc: "http://c-cube.github.io/qcheck/"
 bug-reports: "https://github.com/c-cube/qcheck/issues"
 depends: [
   "dune" {>= "2.8.0"}
-  "base-bytes"
   "base-unix"
+  "qcheck-core" {= version}
+  "qcheck-ounit" {= version}
   "alcotest" {with-test}
   "odoc" {with-doc}
   "ocaml" {>= "4.08.0"}
@@ -27,9 +28,9 @@ build: [
 ]
 dev-repo: "git+https://github.com/c-cube/qcheck.git"
 url {
-  src: "https://github.com/c-cube/qcheck/archive/v0.21.2.tar.gz"
+  src: "https://github.com/c-cube/qcheck/archive/v0.21.3.tar.gz"
   checksum: [
-    "md5=b8e3728fc1b534ee01e3c2b7e2b30bb3"
-    "sha512=67ff77a66ccf046dfede9123a322002f232a0a65b8ce1890795a4a4ba247bc5413f988e7cfd53412418036c2b907e4cbcd7dcd39d7f1fd2481aee60107b075cc"
+    "md5=8930042156873aa8dfa433d7c1bf8463"
+    "sha512=89d8a8a1990cfa8cd839e732f4cc89d68811ae0cc04732668e1e2691e1eb6e3c525f75936bdb261aebdaa3a8845eb717128b0bf21884bbda80d64ba957d2e6e1"
   ]
 }

--- a/packages/upstream-extra/xdg.3.15.2/opam
+++ b/packages/upstream-extra/xdg.3.15.2/opam
@@ -1,8 +1,9 @@
 opam-version: "2.0"
-name: "dyn"
-version: "3.14.0"
-synopsis: "Dynamic type"
-description: "Dynamic type"
+name: "xdg"
+version: "3.15.2"
+synopsis: "XDG Base Directory Specification"
+description:
+  "https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html"
 maintainer: "Jane Street Group, LLC <opensource@janestreet.com>"
 authors: "Jane Street Group, LLC <opensource@janestreet.com>"
 license: "MIT"
@@ -11,9 +12,7 @@ doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
   "dune" {>= "3.12"}
-  "ocaml" {>= "4.08.0"}
-  "ordering" {= version}
-  "pp" {>= "1.1.0"}
+  "ocaml" {>= "4.08"}
   "odoc" {with-doc}
 ]
 build: [
@@ -25,10 +24,10 @@ build: [
 dev-repo: "git+https://github.com/ocaml/dune.git"
 url {
   src:
-    "https://github.com/ocaml/dune/releases/download/3.14.0/dune-3.14.0.tbz"
+    "https://github.com/ocaml/dune/releases/download/3.15.2/dune-3.15.2.tbz"
   checksum: [
-    "sha256=f4d09d89162621fdff424c253fa50c4920d2179fb5b3d1debab7bbe97c68b2fc"
-    "sha512=f5ead1a9a0cc26e00a762e83e107b47c3c3fe9b44d9e505547c385c7938208d4fdcc91a8099512e76ea4a426f3543445b4d75ef0b621dc7dbfdcbb615bc0b999"
+    "sha256=f959980542ca85909b3f3f8e9be65c2b8a375f3a4e3bd83c7ad7a07f2e077933"
+    "sha512=d752b8c09130cf3d564b3a524e3148783b581daa3f9a61d0f52bf4d6995ef73258e71877dbfd8b7516f9a4bac5ad973e80f4fed596df9446e704acc724aac55e"
   ]
 }
-x-commit-hash: "73250f00372d3f28a25963ded6138728f4202663"
+x-commit-hash: "c28817c416ac0b381f6a6938236419ab5d86d6e1"

--- a/packages/upstream/batteries.3.8.0/opam
+++ b/packages/upstream/batteries.3.8.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "batteries"
-version: "3.7.2"
+version: "3.8.0"
 synopsis: "A community-maintained standard library extension"
 maintainer: [
   "Cedric Cellier <rixed@happyleptic.org>"
@@ -17,7 +17,7 @@ bug-reports:
   "https://github.com/ocaml-batteries-team/batteries-included/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" {>= "4.05" & < "5.2"}
+  "ocaml" {>= "4.05" & < "5.3"}
   "camlp-streams"
   "ocamlfind" {>= "1.5.3"}
   "qtest" {with-test & >= "2.5"}
@@ -46,9 +46,9 @@ dev-repo:
   "git+https://github.com/ocaml-batteries-team/batteries-included.git"
 url {
   src:
-    "https://github.com/ocaml-batteries-team/batteries-included/archive/refs/tags/v3.7.2.tar.gz"
+    "https://github.com/ocaml-batteries-team/batteries-included/archive/refs/tags/v3.8.0.tar.gz"
   checksum: [
-    "md5=1fd7bddce07cf5d244fc9427f7b5e4d4"
-    "sha512=c0f2a0fdc8253e0ea999d8d4c58bfbf32b18d251a2e1d9656bf279de5f01a33e9aabac3af4d95f465f8b671e7711ebd37218043face233340a0c11b08fa62f78"
+    "md5=b691e5870f876c6e590d6aa51b4c5457"
+    "sha512=3b0643ff337cd70da8c4b77887d212e82d043a7163fca36588be12186bc86bbcf0d56b13349325f12eabb96c846204c88560786342f50af7bf4e20b9480d3964"
   ]
 }

--- a/packages/upstream/cohttp.5.2.0/opam
+++ b/packages/upstream/cohttp.5.2.0/opam
@@ -34,7 +34,7 @@ homepage: "https://github.com/mirage/ocaml-cohttp"
 doc: "https://mirage.github.io/ocaml-cohttp/"
 bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
 depends: [
-  "ocaml" {>= "4.08"}
+  ("ocaml" {>= "4.08" & < "5.0"} | ("ocaml" {>= "5.0"} & "base-bytes"))
   "dune" {>= "2.0"}
   "re" {>= "1.9.0"}
   "uri" {>= "2.0.0"}

--- a/packages/upstream/conduit-async.6.2.2/opam
+++ b/packages/upstream/conduit-async.6.2.2/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "conduit-async"
-version: "6.2.1"
+version: "6.2.2"
 synopsis: "A network connection establishment library for Async"
 maintainer: "anil@recoil.org"
 authors: [
@@ -34,10 +34,10 @@ build: [
 dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
 url {
   src:
-    "https://github.com/mirage/ocaml-conduit/releases/download/v6.2.1/conduit-6.2.1.tbz"
+    "https://github.com/mirage/ocaml-conduit/releases/download/v6.2.2/conduit-6.2.2.tbz"
   checksum: [
-    "sha256=59d5e7b62437be489b0b79ce11ff90ac04ef39c683e4cefca8587afdc2f55bbb"
-    "sha512=c8e12d843d73cc776850f1b77e805380ac64f6c81b7bc4516befdeacf4785aeb638a0ccc62d7c1990c66edda6bf679c59c93210ffefeafed9a5fa3ec1bfedeca"
+    "sha256=58eabf878fe2a5612f5a4f2b484ff749a5febbea3b3ceeb9af43ac235f2b2445"
+    "sha512=ab8ee5c2b9d879869181d5dfe111aefeefaa10063d89f21d5fc6023e8a7b83738b246dcadce7d583f5b8e918026cdb73cc66b32a8d5c2f874966fa37d5e67719"
   ]
 }
-x-commit-hash: "2977ef8b910d8283f6bd7f96305af5006ee7c7dd"
+x-commit-hash: "18130daf3907388ecb03ab99192fd1ce98561ca8"

--- a/packages/upstream/conduit-lwt-unix.6.2.2/opam
+++ b/packages/upstream/conduit-lwt-unix.6.2.2/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "conduit-lwt-unix"
-version: "6.2.1"
+version: "6.2.2"
 synopsis: "A network connection establishment library for Lwt_unix"
 maintainer: "anil@recoil.org"
 authors: [
@@ -38,10 +38,10 @@ build: [
 dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
 url {
   src:
-    "https://github.com/mirage/ocaml-conduit/releases/download/v6.2.1/conduit-6.2.1.tbz"
+    "https://github.com/mirage/ocaml-conduit/releases/download/v6.2.2/conduit-6.2.2.tbz"
   checksum: [
-    "sha256=59d5e7b62437be489b0b79ce11ff90ac04ef39c683e4cefca8587afdc2f55bbb"
-    "sha512=c8e12d843d73cc776850f1b77e805380ac64f6c81b7bc4516befdeacf4785aeb638a0ccc62d7c1990c66edda6bf679c59c93210ffefeafed9a5fa3ec1bfedeca"
+    "sha256=58eabf878fe2a5612f5a4f2b484ff749a5febbea3b3ceeb9af43ac235f2b2445"
+    "sha512=ab8ee5c2b9d879869181d5dfe111aefeefaa10063d89f21d5fc6023e8a7b83738b246dcadce7d583f5b8e918026cdb73cc66b32a8d5c2f874966fa37d5e67719"
   ]
 }
-x-commit-hash: "2977ef8b910d8283f6bd7f96305af5006ee7c7dd"
+x-commit-hash: "18130daf3907388ecb03ab99192fd1ce98561ca8"

--- a/packages/upstream/conduit-lwt.6.2.2/opam
+++ b/packages/upstream/conduit-lwt.6.2.2/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "conduit-lwt"
-version: "6.2.1"
+version: "6.2.2"
 synopsis: "A portable network connection establishment library using Lwt"
 maintainer: "anil@recoil.org"
 authors: [
@@ -26,10 +26,10 @@ build: [
 dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
 url {
   src:
-    "https://github.com/mirage/ocaml-conduit/releases/download/v6.2.1/conduit-6.2.1.tbz"
+    "https://github.com/mirage/ocaml-conduit/releases/download/v6.2.2/conduit-6.2.2.tbz"
   checksum: [
-    "sha256=59d5e7b62437be489b0b79ce11ff90ac04ef39c683e4cefca8587afdc2f55bbb"
-    "sha512=c8e12d843d73cc776850f1b77e805380ac64f6c81b7bc4516befdeacf4785aeb638a0ccc62d7c1990c66edda6bf679c59c93210ffefeafed9a5fa3ec1bfedeca"
+    "sha256=58eabf878fe2a5612f5a4f2b484ff749a5febbea3b3ceeb9af43ac235f2b2445"
+    "sha512=ab8ee5c2b9d879869181d5dfe111aefeefaa10063d89f21d5fc6023e8a7b83738b246dcadce7d583f5b8e918026cdb73cc66b32a8d5c2f874966fa37d5e67719"
   ]
 }
-x-commit-hash: "2977ef8b910d8283f6bd7f96305af5006ee7c7dd"
+x-commit-hash: "18130daf3907388ecb03ab99192fd1ce98561ca8"

--- a/packages/upstream/conduit.6.2.2/opam
+++ b/packages/upstream/conduit.6.2.2/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "conduit"
-version: "6.2.1"
+version: "6.2.2"
 synopsis: "A network connection establishment library"
 description: """\
 The `conduit` library takes care of establishing and listening for
@@ -49,10 +49,10 @@ build: [
 dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
 url {
   src:
-    "https://github.com/mirage/ocaml-conduit/releases/download/v6.2.1/conduit-6.2.1.tbz"
+    "https://github.com/mirage/ocaml-conduit/releases/download/v6.2.2/conduit-6.2.2.tbz"
   checksum: [
-    "sha256=59d5e7b62437be489b0b79ce11ff90ac04ef39c683e4cefca8587afdc2f55bbb"
-    "sha512=c8e12d843d73cc776850f1b77e805380ac64f6c81b7bc4516befdeacf4785aeb638a0ccc62d7c1990c66edda6bf679c59c93210ffefeafed9a5fa3ec1bfedeca"
+    "sha256=58eabf878fe2a5612f5a4f2b484ff749a5febbea3b3ceeb9af43ac235f2b2445"
+    "sha512=ab8ee5c2b9d879869181d5dfe111aefeefaa10063d89f21d5fc6023e8a7b83738b246dcadce7d583f5b8e918026cdb73cc66b32a8d5c2f874966fa37d5e67719"
   ]
 }
-x-commit-hash: "2977ef8b910d8283f6bd7f96305af5006ee7c7dd"
+x-commit-hash: "18130daf3907388ecb03ab99192fd1ce98561ca8"

--- a/packages/upstream/conf-libffi.2.0.0/opam
+++ b/packages/upstream/conf-libffi.2.0.0/opam
@@ -19,6 +19,7 @@ depexts: [
   ["libffi"] {os = "macos" & os-distribution = "macports"}
   ["libffi-dev"] {os-distribution = "alpine"}
   ["libffi-dev"] {os-family = "debian"}
+  ["libffi-dev"] {os-family = "ubuntu"}
   ["libffi-devel"] {os-distribution = "centos"}
   ["libffi-devel"] {os-distribution = "fedora"}
   ["libffi-devel"] {os-distribution = "mageia"}

--- a/packages/upstream/conf-perl.2/opam
+++ b/packages/upstream/conf-perl.2/opam
@@ -13,6 +13,7 @@ flags: conf
 build: ["perl" "--version"]
 depexts: [
   ["perl"] {os-family = "debian"}
+  ["perl"] {os-family = "ubuntu"}
   ["perl"] {os-distribution = "alpine"}
   ["perl"] {os-distribution = "nixos"}
   ["perl"] {os-distribution = "arch"}

--- a/packages/upstream/conf-pkg-config.3/opam
+++ b/packages/upstream/conf-pkg-config.3/opam
@@ -12,7 +12,10 @@ license: "GPL-1.0-or-later"
 homepage: "http://www.freedesktop.org/wiki/Software/pkg-config/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: conf
-build: ["pkg-config" "--help"] {os != "openbsd"}
+build: [
+  ["pkg-config" "--help"] {os != "openbsd" & os != "win32"}
+  ["pkgconf" "--version"] {os = "win32"}
+]
 depexts: [
   ["pkg-config"] {os-family = "debian" | os-family = "ubuntu"}
   ["pkgconf"] {os-distribution = "arch"}
@@ -22,7 +25,7 @@ depexts: [
   ["pkgconfig"] {os-distribution = "rhel" & os-version <= "7"}
   ["pkgconfig"] {os-distribution = "ol" & os-version <= "7"}
   ["pkgconf"] {os-distribution = "alpine"}
-  ["pkgconfig"] {os-distribution = "nixos"}
+  ["pkg-config"] {os-distribution = "nixos"}
   ["pkg-config"] {os = "macos" & os-distribution = "homebrew"}
   ["pkgconfig"] {os = "macos" & os-distribution = "macports"}
   ["pkgconf"] {os = "freebsd"}
@@ -30,4 +33,5 @@ depexts: [
   ["pkgconf-pkg-config"] {os-distribution = "centos" & os-version >= "8"}
   ["pkgconf-pkg-config"] {os-distribution = "ol" & os-version >= "8"}
   ["system:pkgconf"] {os = "win32" & os-distribution = "cygwinports"}
+  ["pkgconf"] {os = "win32" & os-distribution = "cygwin"}
 ]

--- a/packages/upstream/ctypes-foreign.0.22.0/opam
+++ b/packages/upstream/ctypes-foreign.0.22.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "ctypes-foreign"
-version: "0.21.1"
+version: "0.22.0"
 synopsis: "Dynamic access to foreign C libraries using Ctypes"
 description: """\
 This installs the `ctypes-foreign` interface which
@@ -46,6 +46,6 @@ build: [
 dev-repo: "git+https://github.com/yallop/ocaml-ctypes.git"
 url {
   src:
-    "https://github.com/yallop/ocaml-ctypes/archive/refs/tags/0.21.1.tar.gz"
-  checksum: "md5=8b201d932741c5096854e5eb39139b90"
+    "https://github.com/yallop/ocaml-ctypes/archive/refs/tags/0.22.0.tar.gz"
+  checksum: "md5=8a301a3e3b79156448a6659859ad506c"
 }

--- a/packages/upstream/ctypes.0.22.0/opam
+++ b/packages/upstream/ctypes.0.22.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "ctypes"
-version: "0.21.1"
+version: "0.22.0"
 synopsis: "Combinators for binding to C libraries without writing any C"
 description: """\
 ctypes is a library for binding to C libraries using pure OCaml. The primary
@@ -55,6 +55,6 @@ build: [
 dev-repo: "git+https://github.com/yallop/ocaml-ctypes.git"
 url {
   src:
-    "https://github.com/yallop/ocaml-ctypes/archive/refs/tags/0.21.1.tar.gz"
-  checksum: "md5=8b201d932741c5096854e5eb39139b90"
+    "https://github.com/yallop/ocaml-ctypes/archive/refs/tags/0.22.0.tar.gz"
+  checksum: "md5=8a301a3e3b79156448a6659859ad506c"
 }

--- a/packages/upstream/dune-build-info.3.15.2/opam
+++ b/packages/upstream/dune-build-info.3.15.2/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "dune-build-info"
-version: "3.14.0"
+version: "3.15.2"
 synopsis: "Embed build information inside executable"
 description: """\
 The build-info library allows to access information about how the
@@ -29,10 +29,10 @@ build: [
 dev-repo: "git+https://github.com/ocaml/dune.git"
 url {
   src:
-    "https://github.com/ocaml/dune/releases/download/3.14.0/dune-3.14.0.tbz"
+    "https://github.com/ocaml/dune/releases/download/3.15.2/dune-3.15.2.tbz"
   checksum: [
-    "sha256=f4d09d89162621fdff424c253fa50c4920d2179fb5b3d1debab7bbe97c68b2fc"
-    "sha512=f5ead1a9a0cc26e00a762e83e107b47c3c3fe9b44d9e505547c385c7938208d4fdcc91a8099512e76ea4a426f3543445b4d75ef0b621dc7dbfdcbb615bc0b999"
+    "sha256=f959980542ca85909b3f3f8e9be65c2b8a375f3a4e3bd83c7ad7a07f2e077933"
+    "sha512=d752b8c09130cf3d564b3a524e3148783b581daa3f9a61d0f52bf4d6995ef73258e71877dbfd8b7516f9a4bac5ad973e80f4fed596df9446e704acc724aac55e"
   ]
 }
-x-commit-hash: "73250f00372d3f28a25963ded6138728f4202663"
+x-commit-hash: "c28817c416ac0b381f6a6938236419ab5d86d6e1"

--- a/packages/upstream/dune-configurator.3.15.2/opam
+++ b/packages/upstream/dune-configurator.3.15.2/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "dune-configurator"
-version: "3.14.0"
+version: "3.15.2"
 synopsis: "Helper library for gathering system configuration"
 description: """\
 dune-configurator is a small library that helps writing OCaml scripts that
@@ -33,10 +33,10 @@ build: [
 dev-repo: "git+https://github.com/ocaml/dune.git"
 url {
   src:
-    "https://github.com/ocaml/dune/releases/download/3.14.0/dune-3.14.0.tbz"
+    "https://github.com/ocaml/dune/releases/download/3.15.2/dune-3.15.2.tbz"
   checksum: [
-    "sha256=f4d09d89162621fdff424c253fa50c4920d2179fb5b3d1debab7bbe97c68b2fc"
-    "sha512=f5ead1a9a0cc26e00a762e83e107b47c3c3fe9b44d9e505547c385c7938208d4fdcc91a8099512e76ea4a426f3543445b4d75ef0b621dc7dbfdcbb615bc0b999"
+    "sha256=f959980542ca85909b3f3f8e9be65c2b8a375f3a4e3bd83c7ad7a07f2e077933"
+    "sha512=d752b8c09130cf3d564b3a524e3148783b581daa3f9a61d0f52bf4d6995ef73258e71877dbfd8b7516f9a4bac5ad973e80f4fed596df9446e704acc724aac55e"
   ]
 }
-x-commit-hash: "73250f00372d3f28a25963ded6138728f4202663"
+x-commit-hash: "c28817c416ac0b381f6a6938236419ab5d86d6e1"

--- a/packages/upstream/dune-private-libs.3.15.2/opam
+++ b/packages/upstream/dune-private-libs.3.15.2/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "dune-private-libs"
-version: "3.14.0"
+version: "3.15.2"
 synopsis: "Private libraries of Dune"
 description: """\
 !!!!!!!!!!!!!!!!!!!!!!
@@ -34,10 +34,10 @@ build: [
 dev-repo: "git+https://github.com/ocaml/dune.git"
 url {
   src:
-    "https://github.com/ocaml/dune/releases/download/3.14.0/dune-3.14.0.tbz"
+    "https://github.com/ocaml/dune/releases/download/3.15.2/dune-3.15.2.tbz"
   checksum: [
-    "sha256=f4d09d89162621fdff424c253fa50c4920d2179fb5b3d1debab7bbe97c68b2fc"
-    "sha512=f5ead1a9a0cc26e00a762e83e107b47c3c3fe9b44d9e505547c385c7938208d4fdcc91a8099512e76ea4a426f3543445b4d75ef0b621dc7dbfdcbb615bc0b999"
+    "sha256=f959980542ca85909b3f3f8e9be65c2b8a375f3a4e3bd83c7ad7a07f2e077933"
+    "sha512=d752b8c09130cf3d564b3a524e3148783b581daa3f9a61d0f52bf4d6995ef73258e71877dbfd8b7516f9a4bac5ad973e80f4fed596df9446e704acc724aac55e"
   ]
 }
-x-commit-hash: "73250f00372d3f28a25963ded6138728f4202663"
+x-commit-hash: "c28817c416ac0b381f6a6938236419ab5d86d6e1"

--- a/packages/upstream/dune-site.3.15.2/opam
+++ b/packages/upstream/dune-site.3.15.2/opam
@@ -1,9 +1,7 @@
 opam-version: "2.0"
-name: "chrome-trace"
-version: "3.14.0"
-synopsis: "Chrome trace event generation library"
-description:
-  "This library offers no backwards compatibility guarantees. Use at your own risk."
+name: "dune-site"
+version: "3.15.2"
+synopsis: "Embed locations information inside executable and libraries"
 maintainer: "Jane Street Group, LLC <opensource@janestreet.com>"
 authors: "Jane Street Group, LLC <opensource@janestreet.com>"
 license: "MIT"
@@ -12,7 +10,7 @@ doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
   "dune" {>= "3.12"}
-  "ocaml" {>= "4.08.0"}
+  "dune-private-libs" {= version}
   "odoc" {with-doc}
 ]
 build: [
@@ -24,10 +22,10 @@ build: [
 dev-repo: "git+https://github.com/ocaml/dune.git"
 url {
   src:
-    "https://github.com/ocaml/dune/releases/download/3.14.0/dune-3.14.0.tbz"
+    "https://github.com/ocaml/dune/releases/download/3.15.2/dune-3.15.2.tbz"
   checksum: [
-    "sha256=f4d09d89162621fdff424c253fa50c4920d2179fb5b3d1debab7bbe97c68b2fc"
-    "sha512=f5ead1a9a0cc26e00a762e83e107b47c3c3fe9b44d9e505547c385c7938208d4fdcc91a8099512e76ea4a426f3543445b4d75ef0b621dc7dbfdcbb615bc0b999"
+    "sha256=f959980542ca85909b3f3f8e9be65c2b8a375f3a4e3bd83c7ad7a07f2e077933"
+    "sha512=d752b8c09130cf3d564b3a524e3148783b581daa3f9a61d0f52bf4d6995ef73258e71877dbfd8b7516f9a4bac5ad973e80f4fed596df9446e704acc724aac55e"
   ]
 }
-x-commit-hash: "73250f00372d3f28a25963ded6138728f4202663"
+x-commit-hash: "c28817c416ac0b381f6a6938236419ab5d86d6e1"

--- a/packages/upstream/dune.3.15.2/opam
+++ b/packages/upstream/dune.3.15.2/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "dune"
-version: "3.14.0"
+version: "3.15.2"
 synopsis: "Fast, portable, and opinionated build system"
 description: """\
 Dune is a build system that was designed to simplify the release of
@@ -56,10 +56,10 @@ build: [
 dev-repo: "git+https://github.com/ocaml/dune.git"
 url {
   src:
-    "https://github.com/ocaml/dune/releases/download/3.14.0/dune-3.14.0.tbz"
+    "https://github.com/ocaml/dune/releases/download/3.15.2/dune-3.15.2.tbz"
   checksum: [
-    "sha256=f4d09d89162621fdff424c253fa50c4920d2179fb5b3d1debab7bbe97c68b2fc"
-    "sha512=f5ead1a9a0cc26e00a762e83e107b47c3c3fe9b44d9e505547c385c7938208d4fdcc91a8099512e76ea4a426f3543445b4d75ef0b621dc7dbfdcbb615bc0b999"
+    "sha256=f959980542ca85909b3f3f8e9be65c2b8a375f3a4e3bd83c7ad7a07f2e077933"
+    "sha512=d752b8c09130cf3d564b3a524e3148783b581daa3f9a61d0f52bf4d6995ef73258e71877dbfd8b7516f9a4bac5ad973e80f4fed596df9446e704acc724aac55e"
   ]
 }
-x-commit-hash: "73250f00372d3f28a25963ded6138728f4202663"
+x-commit-hash: "c28817c416ac0b381f6a6938236419ab5d86d6e1"

--- a/packages/upstream/dyn.3.15.2/opam
+++ b/packages/upstream/dyn.3.15.2/opam
@@ -1,8 +1,8 @@
 opam-version: "2.0"
-name: "dune-rpc"
-version: "3.14.0"
-synopsis: "Communicate with dune using rpc"
-description: "Library to connect and control a running dune instance"
+name: "dyn"
+version: "3.15.2"
+synopsis: "Dynamic type"
+description: "Dynamic type"
 maintainer: "Jane Street Group, LLC <opensource@janestreet.com>"
 authors: "Jane Street Group, LLC <opensource@janestreet.com>"
 license: "MIT"
@@ -11,11 +11,8 @@ doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
   "dune" {>= "3.12"}
-  "csexp"
-  "ordering"
-  "dyn"
-  "xdg"
-  "stdune" {= version}
+  "ocaml" {>= "4.08.0"}
+  "ordering" {= version}
   "pp" {>= "1.1.0"}
   "odoc" {with-doc}
 ]
@@ -28,10 +25,10 @@ build: [
 dev-repo: "git+https://github.com/ocaml/dune.git"
 url {
   src:
-    "https://github.com/ocaml/dune/releases/download/3.14.0/dune-3.14.0.tbz"
+    "https://github.com/ocaml/dune/releases/download/3.15.2/dune-3.15.2.tbz"
   checksum: [
-    "sha256=f4d09d89162621fdff424c253fa50c4920d2179fb5b3d1debab7bbe97c68b2fc"
-    "sha512=f5ead1a9a0cc26e00a762e83e107b47c3c3fe9b44d9e505547c385c7938208d4fdcc91a8099512e76ea4a426f3543445b4d75ef0b621dc7dbfdcbb615bc0b999"
+    "sha256=f959980542ca85909b3f3f8e9be65c2b8a375f3a4e3bd83c7ad7a07f2e077933"
+    "sha512=d752b8c09130cf3d564b3a524e3148783b581daa3f9a61d0f52bf4d6995ef73258e71877dbfd8b7516f9a4bac5ad973e80f4fed596df9446e704acc724aac55e"
   ]
 }
-x-commit-hash: "73250f00372d3f28a25963ded6138728f4202663"
+x-commit-hash: "c28817c416ac0b381f6a6938236419ab5d86d6e1"

--- a/packages/upstream/hmap.0.8.1/opam
+++ b/packages/upstream/hmap.0.8.1/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+name: "hmap"
+version: "0.8.1"
+synopsis: "Heterogeneous value maps for OCaml"
+description: """\
+Hmap provides heterogeneous value maps for OCaml. These maps bind keys
+to values with arbitrary types. Keys witness the type of the value
+they are bound to which allows to add and lookup bindings in a type
+safe manner.
+
+Hmap has no dependency and is distributed under the ISC license."""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+license: "ISC"
+tags: ["data-structure" "org:erratique"]
+homepage: "http://erratique.ch/software/hmap"
+doc: "http://erratique.ch/software/hmap/doc"
+bug-reports: "http://github.com/dbuenzli/hmap/issues"
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+]
+build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"]
+dev-repo: "git+http://erratique.ch/repos/hmap.git"
+url {
+  src: "http://erratique.ch/software/hmap/releases/hmap-0.8.1.tbz"
+  checksum: "md5=04169252265a11d852e1547445177196"
+}

--- a/packages/upstream/json-data-encoding.1.0.1/opam
+++ b/packages/upstream/json-data-encoding.1.0.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "json-data-encoding"
-version: "1.0.0"
+version: "1.0.1"
 synopsis: "Type-safe encoding to and decoding from JSON"
 maintainer: "contact@nomadic-labs.com"
 authors: ["Nomadic Labs" "Ocamlpro"]
@@ -24,14 +24,15 @@ conflicts: [
 ]
 build: [
   ["dune" "build" "-j" jobs "-p" name]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "runtest" "-p" name "-j" jobs]
+    {with-test & !ocaml-option-bytecode-only:installed}
 ]
 dev-repo: "git+https://gitlab.com/nomadic-labs/json-data-encoding"
 url {
   src:
-    "https://gitlab.com/nomadic-labs/data-encoding/-/archive/v1.0.0/data-encoding-v1.0.0.tar.gz"
+    "https://gitlab.com/nomadic-labs/data-encoding/-/archive/v1.0.1/data-encoding-v1.0.1.tar.gz"
   checksum: [
-    "md5=d15b03873f0ccc333b60bfcdf0595766"
-    "sha512=0a5355bae421b5d155eeff7ad333cce32cf317b88ac69a07be715ff9a4cd05c8e1715de4917ed8f67789070175654ea3e332a348e586d5005e8772f5672c4a6f"
+    "md5=82d6e7783274595c82cff4562e2b06a2"
+    "sha512=df5d00dfef8afeada8a6aee2a97d491a2ce20cfe90aed203848f6098ba05ba60e2ee9d1afc0c6c07cf32dad3f8e34c0b55cf900ef1f2e7a72d704f07fd32e651"
   ]
 }

--- a/packages/upstream/mirage-crypto-ec.0.10.7/opam
+++ b/packages/upstream/mirage-crypto-ec.0.10.7/opam
@@ -37,7 +37,7 @@ depends: [
   "mirage-crypto-pk" {with-test & = version}
   "hex" {with-test}
   "alcotest" {with-test}
-  "asn1-combinators" {with-test & >= "0.2.5"}
+  "asn1-combinators" {with-test & >= "0.2.5" & < "0.3.0"}
   "ppx_deriving_yojson" {with-test}
   "ppx_deriving" {with-test}
   "yojson" {with-test & >= "1.6.0"}

--- a/packages/upstream/mirage-crypto-pk.0.10.7/opam
+++ b/packages/upstream/mirage-crypto-pk.0.10.7/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.6"}
   "ounit2" {with-test}
-  "randomconv" {with-test & >= "0.1.3"}
+  "randomconv" {with-test & >= "0.1.3" & < "0.2.0"}
   "cstruct" {>= "6.00"}
   "mirage-crypto" {= version}
   "mirage-crypto-rng" {= version}

--- a/packages/upstream/mirage-crypto-rng.0.10.7/opam
+++ b/packages/upstream/mirage-crypto-rng.0.10.7/opam
@@ -23,7 +23,7 @@ depends: [
   "logs"
   "mirage-crypto" {= version}
   "ounit2" {with-test}
-  "randomconv" {with-test & >= "0.1.3"}
+  "randomconv" {with-test & >= "0.1.3" & < "0.2.0"}
   "mtime" {>= "1.0.0"}
   "lwt" {>= "4.0.0"}
 ]

--- a/packages/upstream/ocaml-compiler-libs.v0.12.4/opam
+++ b/packages/upstream/ocaml-compiler-libs.v0.12.4/opam
@@ -12,7 +12,7 @@ homepage: "https://github.com/janestreet/ocaml-compiler-libs"
 bug-reports: "https://github.com/janestreet/ocaml-compiler-libs/issues"
 depends: [
   "dune" {>= "2.8"}
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "5.2.0"}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/upstream/ocaml-version.3.6.7/opam
+++ b/packages/upstream/ocaml-version.3.6.7/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "ocaml-version"
-version: "3.6.4"
+version: "3.6.7"
 synopsis: "Manipulate, parse and generate OCaml compiler version strings"
 description: """\
 This library provides facilities to parse version numbers of the OCaml compiler, and enumerates the various official OCaml releases and configuration variants.
@@ -47,10 +47,10 @@ build: [
 dev-repo: "git+https://github.com/ocurrent/ocaml-version.git"
 url {
   src:
-    "https://github.com/ocurrent/ocaml-version/releases/download/v3.6.4/ocaml-version-3.6.4.tbz"
+    "https://github.com/ocurrent/ocaml-version/releases/download/v3.6.7/ocaml-version-3.6.7.tbz"
   checksum: [
-    "sha256=270bcebfe43881ebc09c897bde5ea3b90737b7673ee4100f8c0c6cff321872dc"
-    "sha512=bc431d9984c6341a08ca8ce68dcead9cbf6a7954aa10966b32ba1d8df0beb363d1ecfcff373b7afc3b301a681dd131fe588bfdb965f2c983db6061f361fec40a"
+    "sha256=d50ffd5b669d33edb0d889c476a71de4888d90008d58336038d210ced28f810c"
+    "sha512=128c2777152d6050a1cc07e520876aa7bef380459dd6a3dbcc8e42352afcbd7ebb8f8ef1751beb865346d49ba6f0c2dc45359f2367e5d4c53906008fc51d95eb"
   ]
 }
-x-commit-hash: "bf2f60c037aa84c41a38f0275c87df9e822d99e2"
+x-commit-hash: "1fd32aebc48b86a81e3f825229180f530a94729a"

--- a/packages/upstream/ocamlformat-lib.0.26.2/opam
+++ b/packages/upstream/ocamlformat-lib.0.26.2/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "ocamlformat-lib"
-version: "0.26.1"
+version: "0.26.2"
 synopsis: "OCaml Code Formatter"
 description:
   "OCamlFormat is a tool to automatically format OCaml code in a uniform style."
@@ -60,10 +60,10 @@ build: [
 dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
 url {
   src:
-    "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.26.1/ocamlformat-0.26.1.tbz"
+    "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.26.2/ocamlformat-0.26.2.tbz"
   checksum: [
-    "sha256=da006e427f15b9ec612fb808d446599bd9b7c3ee25abeb3d555747a70d74c6d7"
-    "sha512=b7413f8dc47ba3a2372e89d59cae54f9a602ab81e31cd14ed986a831111080b79a5a3cc45dac04d8ffae5054c35bf29fe9559f145c76c87a30e191ed5400942a"
+    "sha256=2e4f596bf7aa367a844fe83ba0f6b0bf14b2a65179ddc082363fe9793d0375c5"
+    "sha512=b03d57462e65b11aa9f78dd5c4548251e8d1c5a1c9662f7502bdb10472aeb9df33c1d407350767a5223fbff9c01d53de85bafacd0274b49abc4b43701b159bee"
   ]
 }
-x-commit-hash: "6734dfc1992eb782f0a936ce3cd7c78b7c1d39d3"
+x-commit-hash: "f5727b32127730a2722f86c7119eb6d8f884e26d"

--- a/packages/upstream/ocamlformat.0.26.2/opam
+++ b/packages/upstream/ocamlformat.0.26.2/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "ocamlformat"
-version: "0.26.1"
+version: "0.26.2"
 synopsis: "Auto-formatter for OCaml code"
 description: """\
 **ocamlformat** is a code formatter for OCaml. It comes with opinionated default settings but is also fully customizable to suit your coding style.
@@ -25,7 +25,7 @@ license: "MIT AND LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 homepage: "https://github.com/ocaml-ppx/ocamlformat"
 bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
 depends: [
-  "ocaml" {>= "4.08" & < "5.2"}
+  "ocaml" {>= "4.08"}
   "cmdliner" {with-test = "false" & >= "1.1.0" | with-test & >= "1.2.0"}
   "dune" {>= "2.8"}
   "ocamlformat-lib" {= version}
@@ -50,10 +50,10 @@ build: [
 dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
 url {
   src:
-    "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.26.1/ocamlformat-0.26.1.tbz"
+    "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.26.2/ocamlformat-0.26.2.tbz"
   checksum: [
-    "sha256=da006e427f15b9ec612fb808d446599bd9b7c3ee25abeb3d555747a70d74c6d7"
-    "sha512=b7413f8dc47ba3a2372e89d59cae54f9a602ab81e31cd14ed986a831111080b79a5a3cc45dac04d8ffae5054c35bf29fe9559f145c76c87a30e191ed5400942a"
+    "sha256=2e4f596bf7aa367a844fe83ba0f6b0bf14b2a65179ddc082363fe9793d0375c5"
+    "sha512=b03d57462e65b11aa9f78dd5c4548251e8d1c5a1c9662f7502bdb10472aeb9df33c1d407350767a5223fbff9c01d53de85bafacd0274b49abc4b43701b159bee"
   ]
 }
-x-commit-hash: "6734dfc1992eb782f0a936ce3cd7c78b7c1d39d3"
+x-commit-hash: "f5727b32127730a2722f86c7119eb6d8f884e26d"

--- a/packages/upstream/opentelemetry-client-ocurl.0.9/opam
+++ b/packages/upstream/opentelemetry-client-ocurl.0.9/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
-name: "opentelemetry"
-version: "0.7"
-synopsis: "Instrumentation for https://opentelemetry.io"
+name: "opentelemetry-client-ocurl"
+version: "0.9"
+synopsis: "Collector client for opentelemetry, using http + ezcurl"
 maintainer: [
   "Simon Cruanes <simon.cruanes.2007@m4x.org>"
   "Matt Bray <mattjbray@gmail.com>"
@@ -9,23 +9,17 @@ maintainer: [
 ]
 authors: "the Imandra team and contributors"
 license: "MIT"
-tags: ["instrumentation" "tracing" "opentelemetry" "datadog" "jaeger"]
 homepage: "https://github.com/imandra-ai/ocaml-opentelemetry"
 bug-reports: "https://github.com/imandra-ai/ocaml-opentelemetry/issues"
 depends: [
   "dune" {>= "2.9"}
   "ocaml" {>= "4.08"}
-  "ptime"
-  "ambient-context"
+  "mtime" {>= "1.4"}
+  "opentelemetry" {= version}
   "odoc" {with-doc}
+  "ezcurl" {>= "0.2.3"}
+  "ocurl"
   "alcotest" {with-test}
-  "pbrt" {>= "3.0" & < "4.0"}
-  "ocaml-lsp-server" {with-dev-setup}
-  "ocamlformat" {with-dev-setup & >= "0.24" & < "0.25"}
-]
-depopts: ["trace"]
-conflicts: [
-  "trace" {< "0.4" | >= "0.7"}
 ]
 build: [
   ["dune" "subst"] {dev}
@@ -46,10 +40,10 @@ build: [
 dev-repo: "git+https://github.com/imandra-ai/ocaml-opentelemetry.git"
 url {
   src:
-    "https://github.com/imandra-ai/ocaml-opentelemetry/releases/download/v0.7/opentelemetry-0.7.tbz"
+    "https://github.com/imandra-ai/ocaml-opentelemetry/releases/download/v0.9/opentelemetry-0.9.tbz"
   checksum: [
-    "sha256=a5de04aa33f5b66e4a63377fd868a839814a4ee229c98c84a04bd49926a38e1d"
-    "sha512=f0f9956cb6a605826018794a8fa866b5bda622d2aaa82c4cca5e10262ae163a99512ee22ed4ef0c3af0bb4eeabc7aee736fe7830c585879b029b5ef6d4ef2b05"
+    "sha256=400e6fcaff55b92e65d5c082d0262a7c2fc91b385dac0f18ed28405db2669978"
+    "sha512=9f4d2329dec682bb2a839d1c7065f35bc557fc8ef5996c5923cf05af716e6519b0ce66316687e74232cf93baa5c1df4899d1bdd4b4f4b44468bb8b3f57619913"
   ]
 }
-x-commit-hash: "5a78805addcc09f08e374a4d7b37a4128bcabe69"
+x-commit-hash: "f9233113b130b7426e5d14ec3eee5c24c4bdd71e"

--- a/packages/upstream/opentelemetry.0.9/opam
+++ b/packages/upstream/opentelemetry.0.9/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
-name: "opentelemetry-client-ocurl"
-version: "0.7"
-synopsis: "Collector client for opentelemetry, using http + ezcurl"
+name: "opentelemetry"
+version: "0.9"
+synopsis: "Instrumentation for https://opentelemetry.io"
 maintainer: [
   "Simon Cruanes <simon.cruanes.2007@m4x.org>"
   "Matt Bray <mattjbray@gmail.com>"
@@ -9,17 +9,24 @@ maintainer: [
 ]
 authors: "the Imandra team and contributors"
 license: "MIT"
+tags: ["instrumentation" "tracing" "opentelemetry" "datadog" "jaeger"]
 homepage: "https://github.com/imandra-ai/ocaml-opentelemetry"
 bug-reports: "https://github.com/imandra-ai/ocaml-opentelemetry/issues"
 depends: [
   "dune" {>= "2.9"}
   "ocaml" {>= "4.08"}
-  "mtime" {>= "1.4"}
-  "opentelemetry" {= version}
+  "ptime"
+  "hmap"
+  "ambient-context"
   "odoc" {with-doc}
-  "ezcurl" {>= "0.2.3"}
-  "ocurl"
   "alcotest" {with-test}
+  "pbrt" {>= "3.0" & < "4.0"}
+  "ocaml-lsp-server" {with-dev-setup}
+  "ocamlformat" {with-dev-setup & >= "0.24" & < "0.25"}
+]
+depopts: ["trace"]
+conflicts: [
+  "trace" {< "0.7"}
 ]
 build: [
   ["dune" "subst"] {dev}
@@ -40,10 +47,10 @@ build: [
 dev-repo: "git+https://github.com/imandra-ai/ocaml-opentelemetry.git"
 url {
   src:
-    "https://github.com/imandra-ai/ocaml-opentelemetry/releases/download/v0.7/opentelemetry-0.7.tbz"
+    "https://github.com/imandra-ai/ocaml-opentelemetry/releases/download/v0.9/opentelemetry-0.9.tbz"
   checksum: [
-    "sha256=a5de04aa33f5b66e4a63377fd868a839814a4ee229c98c84a04bd49926a38e1d"
-    "sha512=f0f9956cb6a605826018794a8fa866b5bda622d2aaa82c4cca5e10262ae163a99512ee22ed4ef0c3af0bb4eeabc7aee736fe7830c585879b029b5ef6d4ef2b05"
+    "sha256=400e6fcaff55b92e65d5c082d0262a7c2fc91b385dac0f18ed28405db2669978"
+    "sha512=9f4d2329dec682bb2a839d1c7065f35bc557fc8ef5996c5923cf05af716e6519b0ce66316687e74232cf93baa5c1df4899d1bdd4b4f4b44468bb8b3f57619913"
   ]
 }
-x-commit-hash: "5a78805addcc09f08e374a4d7b37a4128bcabe69"
+x-commit-hash: "f9233113b130b7426e5d14ec3eee5c24c4bdd71e"

--- a/packages/upstream/ordering.3.15.2/opam
+++ b/packages/upstream/ordering.3.15.2/opam
@@ -1,7 +1,8 @@
 opam-version: "2.0"
-name: "dune-site"
-version: "3.14.0"
-synopsis: "Embed locations information inside executable and libraries"
+name: "ordering"
+version: "3.15.2"
+synopsis: "Element ordering"
+description: "Element ordering"
 maintainer: "Jane Street Group, LLC <opensource@janestreet.com>"
 authors: "Jane Street Group, LLC <opensource@janestreet.com>"
 license: "MIT"
@@ -10,7 +11,7 @@ doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
   "dune" {>= "3.12"}
-  "dune-private-libs" {= version}
+  "ocaml" {>= "4.08.0"}
   "odoc" {with-doc}
 ]
 build: [
@@ -22,10 +23,10 @@ build: [
 dev-repo: "git+https://github.com/ocaml/dune.git"
 url {
   src:
-    "https://github.com/ocaml/dune/releases/download/3.14.0/dune-3.14.0.tbz"
+    "https://github.com/ocaml/dune/releases/download/3.15.2/dune-3.15.2.tbz"
   checksum: [
-    "sha256=f4d09d89162621fdff424c253fa50c4920d2179fb5b3d1debab7bbe97c68b2fc"
-    "sha512=f5ead1a9a0cc26e00a762e83e107b47c3c3fe9b44d9e505547c385c7938208d4fdcc91a8099512e76ea4a426f3543445b4d75ef0b621dc7dbfdcbb615bc0b999"
+    "sha256=f959980542ca85909b3f3f8e9be65c2b8a375f3a4e3bd83c7ad7a07f2e077933"
+    "sha512=d752b8c09130cf3d564b3a524e3148783b581daa3f9a61d0f52bf4d6995ef73258e71877dbfd8b7516f9a4bac5ad973e80f4fed596df9446e704acc724aac55e"
   ]
 }
-x-commit-hash: "73250f00372d3f28a25963ded6138728f4202663"
+x-commit-hash: "c28817c416ac0b381f6a6938236419ab5d86d6e1"

--- a/packages/upstream/ppx_deriving_hash.0.1.2/opam
+++ b/packages/upstream/ppx_deriving_hash.0.1.2/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "ppx_deriving_hash"
-version: "0.1.1"
+version: "0.1.2"
 synopsis: "[@@deriving hash]"
 description:
   "Deriver for standard hash functions without extra dependencies."
@@ -32,10 +32,10 @@ build: [
 dev-repo: "git+https://github.com/sim642/ppx_deriving_hash.git"
 url {
   src:
-    "https://github.com/sim642/ppx_deriving_hash/releases/download/0.1.1/ppx_deriving_hash-0.1.1.tbz"
+    "https://github.com/sim642/ppx_deriving_hash/releases/download/0.1.2/ppx_deriving_hash-0.1.2.tbz"
   checksum: [
-    "sha256=bdaaac5ab278eee6ded154e405eb7fa8a2dd2b7483032628ce56ef21ae062f24"
-    "sha512=2f19db33fe08c7deb196c7040d649713e5a45389b4cc4074f49b25c9744cd9c70fcd6cdb4814981418d4a7120eecddbeabb7f63688080517c777000dba857655"
+    "sha256=b2cdce00b0fef439b9c2dc20bd0d1248bec2bb4c56ba6c0a98b04a3c387815af"
+    "sha512=3bd89f1215439a20aa81f8eae46574d8b80800a059ce4590774616e5ec349f73f010e0126c3390909942f8c5c258b67ab0ef10df7a5084322861a542a4ec8399"
   ]
 }
-x-commit-hash: "221737ebcfed3dfe8d6af981739c7c335c4822e6"
+x-commit-hash: "c916f11a2365b3fe2ab77096b6073ebf62ea082b"

--- a/packages/upstream/ppxlib.0.32.1/opam
+++ b/packages/upstream/ppxlib.0.32.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "ppxlib"
-version: "0.32.0"
+version: "0.32.1"
 synopsis: "Standard infrastructure for ppx rewriters"
 description: """\
 Ppxlib is the standard infrastructure for ppx rewriters
@@ -21,7 +21,7 @@ doc: "https://ocaml-ppx.github.io/ppxlib/"
 bug-reports: "https://github.com/ocaml-ppx/ppxlib/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" {>= "4.04.1" & < "5.2.0" & != "5.1.0~alpha1"}
+  "ocaml" {>= "4.04.1" & < "5.3.0"}
   "ocaml-compiler-libs" {>= "v0.11.0"}
   "ppx_derivers" {>= "1.0"}
   "sexplib0" {>= "v0.12"}
@@ -34,6 +34,8 @@ depends: [
 ]
 conflicts: [
   "ocaml-migrate-parsetree" {< "2.0.0"}
+  "ocaml-base-compiler" {= "5.1.0~alpha1"}
+  "ocaml-variants" {= "5.1.0~alpha1+options"}
   "base-effects"
 ]
 build: [
@@ -53,10 +55,10 @@ build: [
 dev-repo: "git+https://github.com/ocaml-ppx/ppxlib.git"
 url {
   src:
-    "https://github.com/ocaml-ppx/ppxlib/releases/download/0.32.0/ppxlib-0.32.0.tbz"
+    "https://github.com/ocaml-ppx/ppxlib/releases/download/0.32.1/ppxlib-0.32.1.tbz"
   checksum: [
-    "sha256=507cc73ccf895f22eeb5257a2243838c18a38a09105fcff55eeef9148555422b"
-    "sha512=73fef8ab8761bfbfde6ae87cc51eaacc5a5c937f0d628a890f0abdb2bffbf073932c25287a9e3baa2a1947c37f3dfa7f83ddd33c440e2e800971015addc97cd2"
+    "sha256=9dbad8bcb1c8b4f3df3f58bca60a5ed23d86531f0da34b4196c86bd585c09d7f"
+    "sha512=7b93b622b119478dde03adcf4993e73ea937c91c280e453ccee631c682d8589ecb31841f11d6a14966239954e22e000da8afbe25a0f089532c7210b698c52553"
   ]
 }
-x-commit-hash: "ad46a4c87f99a44dc70b2ec4c42caec2ccacc3c3"
+x-commit-hash: "cd138a752ae6f21ad649c531b3b2276f332b3bb0"

--- a/packages/upstream/qcheck-core.0.21.3/opam
+++ b/packages/upstream/qcheck-core.0.21.3/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
-name: "qcheck"
-version: "0.21.2"
-synopsis: "Compatibility package for qcheck"
+name: "qcheck-core"
+version: "0.21.3"
+synopsis: "Core qcheck library"
 maintainer: "simon.cruanes.2007@m4x.org"
 authors: "the qcheck contributors"
 license: "BSD-2-Clause"
@@ -11,10 +11,7 @@ doc: "http://c-cube.github.io/qcheck/"
 bug-reports: "https://github.com/c-cube/qcheck/issues"
 depends: [
   "dune" {>= "2.8.0"}
-  "base-bytes"
   "base-unix"
-  "qcheck-core" {= version}
-  "qcheck-ounit" {= version}
   "alcotest" {with-test}
   "odoc" {with-doc}
   "ocaml" {>= "4.08.0"}
@@ -29,9 +26,9 @@ build: [
 ]
 dev-repo: "git+https://github.com/c-cube/qcheck.git"
 url {
-  src: "https://github.com/c-cube/qcheck/archive/v0.21.2.tar.gz"
+  src: "https://github.com/c-cube/qcheck/archive/v0.21.3.tar.gz"
   checksum: [
-    "md5=b8e3728fc1b534ee01e3c2b7e2b30bb3"
-    "sha512=67ff77a66ccf046dfede9123a322002f232a0a65b8ce1890795a4a4ba247bc5413f988e7cfd53412418036c2b907e4cbcd7dcd39d7f1fd2481aee60107b075cc"
+    "md5=8930042156873aa8dfa433d7c1bf8463"
+    "sha512=89d8a8a1990cfa8cd839e732f4cc89d68811ae0cc04732668e1e2691e1eb6e3c525f75936bdb261aebdaa3a8845eb717128b0bf21884bbda80d64ba957d2e6e1"
   ]
 }

--- a/packages/upstream/stdune.3.15.2/opam
+++ b/packages/upstream/stdune.3.15.2/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
-name: "ocamlc-loc"
-version: "3.14.0"
-synopsis: "Parse ocaml compiler output into structured form"
+name: "stdune"
+version: "3.15.2"
+synopsis: "Dune's unstable standard library"
 description:
   "This library offers no backwards compatibility guarantees. Use at your own risk."
 maintainer: "Jane Street Group, LLC <opensource@janestreet.com>"
@@ -13,11 +13,12 @@ bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
   "dune" {>= "3.12"}
   "ocaml" {>= "4.08.0"}
+  "base-unix"
   "dyn" {= version}
+  "ordering" {= version}
+  "pp" {>= "1.2.0"}
+  "csexp" {>= "1.5.0"}
   "odoc" {with-doc}
-]
-conflicts: [
-  "ocaml-lsp-server" {< "1.15.0"}
 ]
 build: [
   ["dune" "subst"] {dev}
@@ -28,10 +29,10 @@ build: [
 dev-repo: "git+https://github.com/ocaml/dune.git"
 url {
   src:
-    "https://github.com/ocaml/dune/releases/download/3.14.0/dune-3.14.0.tbz"
+    "https://github.com/ocaml/dune/releases/download/3.15.2/dune-3.15.2.tbz"
   checksum: [
-    "sha256=f4d09d89162621fdff424c253fa50c4920d2179fb5b3d1debab7bbe97c68b2fc"
-    "sha512=f5ead1a9a0cc26e00a762e83e107b47c3c3fe9b44d9e505547c385c7938208d4fdcc91a8099512e76ea4a426f3543445b4d75ef0b621dc7dbfdcbb615bc0b999"
+    "sha256=f959980542ca85909b3f3f8e9be65c2b8a375f3a4e3bd83c7ad7a07f2e077933"
+    "sha512=d752b8c09130cf3d564b3a524e3148783b581daa3f9a61d0f52bf4d6995ef73258e71877dbfd8b7516f9a4bac5ad973e80f4fed596df9446e704acc724aac55e"
   ]
 }
-x-commit-hash: "73250f00372d3f28a25963ded6138728f4202663"
+x-commit-hash: "c28817c416ac0b381f6a6938236419ab5d86d6e1"

--- a/packages/upstream/trace.0.7/opam
+++ b/packages/upstream/trace.0.7/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+name: "trace"
+version: "0.7"
+synopsis:
+  "A stub for tracing/observability, agnostic in how data is collected"
+maintainer: "Simon Cruanes"
+authors: "Simon Cruanes"
+license: "MIT"
+tags: ["trace" "tracing" "observability" "profiling"]
+homepage: "https://github.com/c-cube/ocaml-trace"
+bug-reports: "https://github.com/c-cube/ocaml-trace/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.9"}
+  "odoc" {with-doc}
+]
+depopts: [
+  "hmap"
+  "mtime" {>= "2.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/c-cube/ocaml-trace.git"
+url {
+  src:
+    "https://github.com/c-cube/ocaml-trace/releases/download/v0.7/trace-0.7.tbz"
+  checksum: [
+    "sha256=ebd0be29b30b49536c9659882790b9f0c121ffb06c0bec2eaeba8cfed4909339"
+    "sha512=d14b72db713315093c931351b9b04d2fd5ce793a8595970fa31cbf71477516ef25de129adddf4075514581fe9ea3e27d998530efacb17c0d00bb5616b8d18b91"
+  ]
+}
+x-commit-hash: "62063f3f941224b6532d588f0926cd3a22cc194a"

--- a/packages/upstream/x509.0.16.5/opam
+++ b/packages/upstream/x509.0.16.5/opam
@@ -23,7 +23,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "1.2"}
   "cstruct" {>= "6.0.0"}
-  "asn1-combinators" {>= "0.2.0"}
+  "asn1-combinators" {>= "0.2.0" & < "0.3.0"}
   "ptime"
   "base64" {>= "3.3.0"}
   "mirage-crypto"


### PR DESCRIPTION
Most of them have small fixes, or add ocaml 5.2 compatibility. I want to keep changes to a minimum before using ocaml 4.14.2, I'll force the new interface for mirage-crypto on the next update