### PR TITLE
ci: add Edwin's disk switch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,6 +35,17 @@ jobs:
       - name: Free space
         run: sudo rm -rf /usr/local/lib/android
 
+      - name: Use disk with more space for TMPDIR and XDG_CACHE_HOME
+        shell: bash
+        run: |
+          df -h || true
+          export TMPDIR="/mnt/build/tmp"
+          export XDG_CACHE_HOME="/mnt/build/cache"
+          sudo mkdir -p "${TMPDIR}" "${XDG_CACHE_HOME}"
+          sudo chown "$(id -u):$(id -g)" "${TMPDIR}" "${XDG_CACHE_HOME}"
+          echo "TMPDIR=${TMPDIR}" >>"$GITHUB_ENV"
+          echo "XDG_CACHE_HOME=${XDG_CACHE_HOME}" >>"$GITHUB_ENV"
+
       - name: Use ocaml
         uses: ocaml/setup-ocaml@v2
         with:
@@ -69,3 +80,7 @@ jobs:
 
       - name: Install developer tools
         run: opam install upstream-extra-dummy
+
+      - name: Print disk usage
+        shell: bash
+        run: df -h || true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,15 +68,22 @@ jobs:
 
       - name: Build xs-toolstack, test its dependencies
         # opam install may ignore installing depexts sometimes
-        # OPAMCOLOR is set to "always" by default and it breaks piping
         run: |
-          OPAMERRLOGLEN=10000 OPAMCOLOR=NEVER opam list -s --required-by xs-toolstack | xargs opam depext -tu
-          OPAMERRLOGLEN=10000 OPAMCOLOR=NEVER opam list -s --required-by xs-toolstack | xargs opam install -t
+          opam list -s --required-by xs-toolstack | xargs opam depext -tu
+          opam list -s --required-by xs-toolstack | xargs opam install -t
+        env:
+          # OPAMCOLOR is set to "always" by default and it breaks piping
+          OPAMCOLOR: NEVER
+          OPAMERRLOGLEN: 10000
 
       - name: Uninstall unversioned packages
         # This should purge them from the cache, unversioned package have
         # 'master' as its version
-        run: OPAMCOLOR=NEVER opam list | awk -F " " '$2 == "master" { print $1 }' |  xargs opam uninstall
+        run: opam list | awk -F " " '$2 == "master" { print $1 }' |  xargs opam uninstall
+        env:
+          # OPAMCOLOR is set to "always" by default and it breaks piping
+          OPAMCOLOR: NEVER
+          OPAMERRLOGLEN: 10000
 
       - name: Install developer tools
         run: opam install upstream-extra-dummy

--- a/tools/xs-opam-ci.env
+++ b/tools/xs-opam-ci.env
@@ -1,5 +1,5 @@
 export OCAML_VERSION="4.14"
-export OCAML_VERSION_FULL="4.14.1"
+export OCAML_VERSION_FULL="4.14.2"
 export DISTRO="debian-10"
 export BASE_REMOTE="https://github.com/xapi-project/xs-opam.git"
 export REPOSITORY="https://github.com/xapi-project/xs-opam.git"


### PR DESCRIPTION
The current removal of files in the root filesystem is not enough anymore. Since it takes more than half a minute to remove these files and doesn't provide us with enough benefit, instead use Edwin's change of disks from
https://github.com/xapi-project/xen-api/commit/534eb8dc1d0c37e28a67da4fc53e4cd60e11ab62

This alone has avoided xapi's workflow from running out of disk space, so hopefully it also works here.

Example of run failing due to lack of disk space: https://github.com/xapi-project/xs-opam/actions/runs/9459249982/job/26056017881