### PR TITLE
IH-583: Add new dependencies of the standalone systemd implementation

### DIFF
--- a/packages/xs-extra/xapi-stdext-unix.master/opam
+++ b/packages/xs-extra/xapi-stdext-unix.master/opam
@@ -13,6 +13,8 @@ depends: [
   "fd-send-recv" {>= "2.0.0"}
   "odoc" {with-doc}
   "xapi-backtrace"
+  "unix-errno"
+  "astring"
   "xapi-stdext-pervasives" {= version}
 ]
 available: os = "macos" | os = "linux"


### PR DESCRIPTION
Depends on https://github.com/xapi-project/xen-api/pull/5721/

Added `unix-errno` and `astring` as dependencies for the standalone implementation - these are already packaged. 