### PR TITLE
[maintenance]: SPDX license identifiers are not case sensitive

### DIFF
--- a/tools/license-check.sh
+++ b/tools/license-check.sh
@@ -13,7 +13,7 @@ do
     errors=true
   fi
   license=$(grep -Po 'license: \K.*' $file| tr -d '"')
-  if echo $license | grep -qxvf .github/known-licenses.txt; then 
+  if echo $license | grep -iqxvf .github/known-licenses.txt; then 
     echo "Unrecognised license used for $name: $license. Is it a valid a SPDX identifier?"
     errors=true
   fi


### PR DESCRIPTION
https://spdx.github.io/spdx-spec/v2.3/SPDX-license-expressions/#d2-case-sensitivity says:
> License expression operators (AND, OR and WITH) should be matched in a case-sensitive manner.
> License identifiers (including license exception identifiers) used in SPDX documents or source code files should be matched in a case-insensitive manner