### PR TITLE
update ezxenstore.opam dependencies [epoll]

### DIFF
--- a/packages/xs-extra/ezxenstore.master/opam
+++ b/packages/xs-extra/ezxenstore.master/opam
@@ -10,10 +10,11 @@ dev-repo: "git+https://github.com/xapi-project/xen-api.git"
 build: [[ "dune" "build" "-p" name "-j" jobs ]]
 depends: [
   "ocaml"
-  "dune" {>= "1.4"}
-  "cmdliner" {with-test & >= "1.1.0"}
+  "dune" {>= "3.15"}
+  "cmdliner"
   "logs"
   "uuidm"
+  "xapi-stdext-unix"
   "xenctrl"
   "xenstore"
   "xenstore_transport"

--- a/packages/xs-extra/xapi-rrdd.master/opam
+++ b/packages/xs-extra/xapi-rrdd.master/opam
@@ -21,6 +21,7 @@ depends: [
   "ppx_deriving_rpc"
   "rpclib"
   "ezxenstore" {= version}
+  "rrd-transport" {= version}
   "uuid" {= version}
   "xapi-backtrace"
   "xapi-idl" {= version}


### PR DESCRIPTION
Equivalent commit in XAPI is in this PR:
https://github.com/xapi-project/xen-api/pull/5982/commits/0a8fc6e64b0c59a8cb2d5ddf6d9fba68e9d0e7b3

This is fallout from the epoll merge which introduced this additional dependency, and although it didn't cause a failure in the XAPI CI, it did one here.