### PR TITLE
maintenance: prepare for opam 2.3.0

### DIFF
--- a/packages/upstream/jst-config.v0.15.1/opam
+++ b/packages/upstream/jst-config.v0.15.1/opam
@@ -19,6 +19,10 @@ bug-reports: "https://github.com/janestreet/jst-config/issues"
 patches: [
   "a5cddd0e657b9fc3f6775da8ebdaa6d25446b649.patch"
 ]
+extra-files: [
+  "a5cddd0e657b9fc3f6775da8ebdaa6d25446b649.patch"
+  "md5=f838be8f69845de18b46a0b9cbf60c54"
+]
 depends: [
   "ocaml" {>= "4.08.0"}
   "base" {>= "v0.15" & < "v0.16"}


### PR DESCRIPTION
Run opam admin update-extrafiles to add the missing metadata for the jst-config patch, otherwise opam 2.3.0 refuses to load the file.