### PR TITLE
xapi-test-utils: add crowbar to the dependencies

### DIFF
--- a/packages/xapi-test-utils/xapi-test-utils.1.4.0/opam
+++ b/packages/xapi-test-utils/xapi-test-utils.1.4.0/opam
@@ -12,6 +12,7 @@ depends: [
   "alcotest"
   "ocaml"
   "dune" {build}
+  "crowbar"
 ]
 build: ["dune" "build" "-p" name "-j" jobs]
 dev-repo: "git+https://github.com/xapi-project/xapi-test-utils.git"


### PR DESCRIPTION
This dependency is missed by the current cropping of dependencies.