### PR TITLE
Add ocaml-system-4.14.3 to test dev version

### DIFF
--- a/packages/ocaml-system/ocaml-system.4.14.3+dev-xapi-2025-02-13/opam
+++ b/packages/ocaml-system/ocaml-system.4.14.3+dev-xapi-2025-02-13/opam
@@ -1,0 +1,70 @@
+opam-version: "2.0"
+name: "ocaml-system"
+version: "4.14.3+dev-xapi-2025-02-13"
+synopsis: "The OCaml compiler (system version, from outside of opam)"
+maintainer: [
+  "David Allsopp <david@tarides.com>"
+  "Florian Angeletti <florian.angeletti@inria.fr>"
+]
+authors: "Xavier Leroy and many contributors"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+depends: [
+  "ocaml" {>= "4.14.3~" & < "4.14.4~" & post}
+  "base-unix" {post}
+  "base-threads" {post}
+  "base-bigarray" {post}
+  "host-arch-arm32" {?sys-ocaml-arch & sys-ocaml-arch = "arm" & post}
+  "host-arch-arm64" {?sys-ocaml-arch & sys-ocaml-arch = "arm64" & post}
+  "host-arch-ppc64" {?sys-ocaml-arch & sys-ocaml-arch = "power" & post}
+  "host-arch-riscv64" {?sys-ocaml-arch & sys-ocaml-arch = "riscv" & post}
+  "host-arch-s390x" {?sys-ocaml-arch & sys-ocaml-arch = "s390x" & post}
+  "host-arch-x86_32" {?sys-ocaml-arch & sys-ocaml-arch = "i686" & post}
+  "host-arch-x86_64" {?sys-ocaml-arch & sys-ocaml-arch = "x86_64" & post}
+  "host-arch-unknown"
+    {(!?sys-ocaml-arch) |
+     sys-ocaml-arch != "arm" & sys-ocaml-arch != "arm64" &
+     sys-ocaml-arch != "power" &
+     sys-ocaml-arch != "riscv" &
+     sys-ocaml-arch != "s390x" &
+     sys-ocaml-arch != "i686" &
+     sys-ocaml-arch != "x86_64" &
+     post}
+  "host-system-mingw"
+    {?sys-ocaml-arch & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & post}
+  "host-system-msvc" {?sys-ocaml-arch & sys-ocaml-cc = "msvc" & post}
+  "host-system-other" {?sys-ocaml-arch & sys-ocaml-libc != "msvc" & post}
+  "conf-mingw-w64-gcc-x86_64"
+    {?sys-ocaml-arch & sys-ocaml-arch = "x86_64" & sys-ocaml-libc = "msvc" &
+     sys-ocaml-cc = "cc" &
+     post}
+  "conf-mingw-w64-gcc-i686"
+    {?sys-ocaml-arch & sys-ocaml-arch = "i686" & sys-ocaml-libc = "msvc" &
+     sys-ocaml-cc = "cc" &
+     post}
+  "mingw-w64-shims"
+    {?sys-ocaml-arch & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" &
+     os-distribution = "cygwin" &
+     post}
+  "ocaml-env-msvc32"
+    {?sys-ocaml-arch & sys-ocaml-arch = "i686" & sys-ocaml-cc = "msvc" & post}
+  "ocaml-env-msvc64"
+    {?sys-ocaml-arch & sys-ocaml-arch = "x86_64" & sys-ocaml-cc = "msvc" &
+     post}
+]
+conflict-class: "ocaml-core-compiler"
+available:
+  (sys-ocaml-version >= "4.14.3~" & sys-ocaml-version < "4.14.4" ) & (os != "win32" | sys-ocaml-libc = "msvc")
+flags: compiler
+build: ["ocaml" "gen_ocaml_config.ml"]
+substs: "gen_ocaml_config.ml"
+dev-repo: "git+https://github.com/ocaml/ocaml"
+extra-source "gen_ocaml_config.ml.in" {
+  src:
+    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-system/gen_ocaml_config.ml.in"
+  checksum: [
+    "sha256=71bcd3d35e28cbf71eda81991c8741268f4b87ced71573b2e75f64f136cebfc1"
+    "md5=093e7bec1ec95f9e4c6a313d73c5d840"
+  ]
+}

--- a/packages/ocaml/ocaml.4.14.3/opam
+++ b/packages/ocaml/ocaml.4.14.3/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+name: "ocaml"
+version: "4.14.3"
+synopsis: "The OCaml compiler (virtual package)"
+description: """\
+This package requires a matching implementation of OCaml,
+and polls it to initialise specific variables like `ocaml:native-dynlink`"""
+maintainer: "David Allsopp <david@tarides.com>"
+authors: [
+  "Xavier Leroy"
+  "Damien Doligez"
+  "Alain Frisch"
+  "Jacques Garrigue"
+  "Didier Rémy"
+  "Jérôme Vouillon"
+]
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+depends: [
+  "ocaml-config" {>= "2"}
+  "ocaml-base-compiler" {>= "4.14.3~" & < "4.14.4~"} |
+  "ocaml-variants" {>= "4.14.3~" & < "4.14.4~"} |
+  "ocaml-system" {>= "4.14.3" & < "4.14.4~"} |
+  "dkml-base-compiler" {>= "4.14.3~" & < "4.14.4~"}
+]
+flags: conf
+setenv: [
+  [CAML_LD_LIBRARY_PATH = "%{_:stubsdir}%"]
+  [CAML_LD_LIBRARY_PATH += "%{lib}%/stublibs"]
+  [OCAML_TOPLEVEL_PATH = "%{toplevel}%"]
+]
+build: [
+  "ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name
+]
+build-env: CAML_LD_LIBRARY_PATH = ""
+x-env-path-rewrite: [
+  [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+]


### PR DESCRIPTION
Enable testing the latest OCaml 4.14 branch, which will report itself as 4.14.3.

The opam file in ocaml-system expects an exact match in gen_ocaml_config.ml though, so include the full version in the package version.
OTOH including the full package version in the 'ocaml' package fails with a version  mismatch (that one wants just major.minor.patch).

This is just for testing purposes for now to test the latest OCaml 4.14 branch from github, when you have it installed as a system compiler.