### PR TITLE
github: update image for yangtze's scheduled CI

### DIFF
--- a/.github/workflows/yangtze-lcm.yml
+++ b/.github/workflows/yangtze-lcm.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Update apt cache
         run: sudo apt-get update


### PR DESCRIPTION
In 2 days the image is being removed, making the tests fail continuously

Needs https://github.com/xapi-project/xs-opam/pull/727 merged before runs are successful