### PR TITLE
packages: update mirage-crypto to 2.0.1

### DIFF
--- a/packages/asn1-combinators/asn1-combinators.0.3.2/opam
+++ b/packages/asn1-combinators/asn1-combinators.0.3.2/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "asn1-combinators"
-version: "0.2.6"
+version: "0.3.2"
 synopsis: "Embed typed ASN.1 grammars in OCaml"
 description: """\
 asn1-combinators is a library for expressing ASN.1 in OCaml. Skip the notation
@@ -16,12 +16,11 @@ homepage: "https://github.com/mirleft/ocaml-asn1-combinators"
 doc: "https://mirleft.github.io/ocaml-asn1-combinators/doc"
 bug-reports: "https://github.com/mirleft/ocaml-asn1-combinators/issues"
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.13.0"}
   "dune" {>= "1.2.0"}
-  "cstruct" {>= "6.0.0"}
-  "zarith"
-  "ptime"
-  "alcotest" {with-test}
+  "ptime" {>= "0.8.6"}
+  "alcotest" {with-test & >= "0.8.1"}
+  "ohex" {with-test & >= "0.2.0"}
 ]
 build: [
   ["dune" "subst"] {dev}
@@ -31,10 +30,11 @@ build: [
 dev-repo: "git+https://github.com/mirleft/ocaml-asn1-combinators.git"
 url {
   src:
-    "https://github.com/mirleft/ocaml-asn1-combinators/releases/download/v0.2.6/asn1-combinators-v0.2.6.tbz"
+    "https://github.com/mirleft/ocaml-asn1-combinators/releases/download/v0.3.2/asn1-combinators-0.3.2.tbz"
   checksum: [
-    "sha256=012ade0d8869ef621063752c1cf8ea026f6bc702fed10df9af56688e291b1a91"
-    "sha512=4c1b28f1d230395ff1ad3b8e8d03981b10015062ec270f29e2521914eb64c2fa4d5df68363e339e9a1158c3b58aef0e25156f7ec6addd85a580fecadc17edfac"
+    "sha256=2b26985f6e2722073dcd9f84355bd6757e12643b5a48e30b3c07ff7cfb0d8a7f"
+    "sha512=8ca5a9dfa080cd2e6c3ef05a232e90916df921b09e8445728c6b46438d39056ccb8cd61325f3858490f032a17620a0de17f9d910fd8f0cabe961b02bc76a2eca"
   ]
 }
-x-commit-hash: "1fc666e8b4231846cf65704ffcb09d240981dcb6"
+x-commit-hash: "2f80f3495ccfa88a506d83b811d74f0a2bd63114"
+x-maintenance-intent: ["(latest)"]

--- a/packages/ca-certs/ca-certs.1.0.1/opam
+++ b/packages/ca-certs/ca-certs.1.0.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "ca-certs"
-version: "0.2.3"
+version: "1.0.1"
 synopsis: "Detect root CA certificates from the operating system"
 description: """\
 TLS requires a set of root anchors (Certificate Authorities) to
@@ -16,14 +16,15 @@ doc: "https://mirage.github.io/ca-certs/doc"
 bug-reports: "https://github.com/mirage/ca-certs/issues"
 depends: [
   "dune" {>= "2.0"}
-  "astring"
   "bos"
   "fpath"
   "ptime"
   "logs"
-  "mirage-crypto" {< "1.0.0"}
-  "x509" {>= "0.13.0"}
-  "ocaml" {>= "4.08.0"}
+  "digestif" {>= "1.2.0"}
+  "mirage-crypto" {>= "1.0.0"}
+  "x509" {>= "1.0.0"}
+  "ocaml" {>= "4.13.0"}
+  "ohex" {>= "0.2.0"}
   "alcotest" {with-test}
   "fmt" {with-test & >= "0.8.7"}
 ]
@@ -48,10 +49,11 @@ depexts: ["ca_root_nss"] {os = "freebsd"}
 dev-repo: "git+https://github.com/mirage/ca-certs.git"
 url {
   src:
-    "https://github.com/mirage/ca-certs/releases/download/v0.2.3/ca-certs-0.2.3.tbz"
+    "https://github.com/mirage/ca-certs/releases/download/v1.0.1/ca-certs-1.0.1.tbz"
   checksum: [
-    "sha256=d2d8d6457d915ef6d783def82f3be5ec2f56f92e20214f58edd63c9c2fc60e9c"
-    "sha512=e945112be3b2f1fbcaeb95aebb600cd5119f1f05583ebcc0a4a20dd159d8cfec5adc3443aae678ee159c0e0c32b1d7c0ba3ba4405e3483e3f565e4d29d3da0f7"
+    "sha256=d3cd7c8f548baecef208d425877a811d898ec7d1d9c4bdea6f78652c7c8361cc"
+    "sha512=cb2e2c509531a4824b035762e57217143d7eec7bc57434845b65850144051344b4ed27d61972b6580b83d2d012766919c101a0274fb6218c4e4f65b45d3c79fa"
   ]
 }
-x-commit-hash: "9ee07b8ab77eb9ec8b6d84f98359e45e1beb9b9d"
+x-commit-hash: "319c8a6e7c06da6a4fc3dab5db41cdd28be2e9cf"
+x-maintenance-intent: ["(latest)"]

--- a/packages/digestif/digestif.1.3.0/opam
+++ b/packages/digestif/digestif.1.3.0/opam
@@ -1,0 +1,70 @@
+opam-version: "2.0"
+name: "digestif"
+version: "1.3.0"
+synopsis: "Hashes implementations (SHA*, RIPEMD160, BLAKE2* and MD5)"
+description: """\
+Digestif is a toolbox to provide hashes implementations in C and OCaml.
+
+It uses the linking trick and user can decide at the end to use the C implementation or the OCaml implementation.
+
+We provides implementation of:
+ * MD5
+ * SHA1
+ * SHA224
+ * SHA256
+ * SHA384
+ * SHA512
+ * SHA3
+ * Keccak-256
+ * WHIRLPOOL
+ * BLAKE2B
+ * BLAKE2S
+ * RIPEMD160"""
+maintainer: [
+  "Eyyüb Sari <eyyub.sari@epitech.eu>"
+  "Romain Calascibetta <romain.calascibetta@gmail.com>"
+]
+authors: [
+  "Eyyüb Sari <eyyub.sari@epitech.eu>"
+  "Romain Calascibetta <romain.calascibetta@gmail.com>"
+]
+license: "MIT"
+homepage: "https://github.com/mirage/digestif"
+doc: "https://mirage.github.io/digestif/"
+bug-reports: "https://github.com/mirage/digestif/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.6.0"}
+  "eqaf"
+  "fmt" {with-test & >= "0.8.7"}
+  "alcotest" {with-test}
+  "bos" {with-test}
+  "astring" {with-test}
+  "fpath" {with-test}
+  "rresult" {with-test}
+  "ocamlfind" {with-test}
+  "crowbar" {with-test}
+]
+conflicts: [
+  "mirage-xen" {< "6.0.0"}
+  "ocaml-freestanding"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+install: [
+  ["dune" "install" "-p" name] {with-test}
+  ["ocaml" "./test/test_runes.ml"] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/digestif.git"
+url {
+  src:
+    "https://github.com/mirage/digestif/releases/download/v1.3.0/digestif-1.3.0.tbz"
+  checksum: [
+    "sha256=9a6cdcb332539c87f4723fc3bd73626b2675a7b1161fdf0fed309186ce18f427"
+    "sha512=986d98eeb79f75ff69842a7ed4b93b4ff3795df7c09d455ca0c41408d67415a6743253a96c7e0de653dc62db95cb1fd29b1c654472fa11259cddde65dd5dd352"
+  ]
+}
+x-commit-hash: "0763eb3b34ac8881925c4f50055f4bff3808aed4"
+x-maintenance-intent: ["(latest)"]

--- a/packages/kdf/kdf.1.0.0/opam
+++ b/packages/kdf/kdf.1.0.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+name: "kdf"
+version: "1.0.0"
+synopsis:
+  "Key Derivation Functions: HKDF RFC 5869, PBKDF RFC 2898, SCRYPT RFC 7914"
+description: """\
+A pure OCaml implementation of [scrypt](https://tools.ietf.org/html/rfc7914),
+[PBKDF 1 and 2 as defined by PKCS#5](https://tools.ietf.org/html/rfc2898),
+and [HKDF](https://tools.ietf.org/html/rfc5869)."""
+maintainer: [
+  "Alfredo Beaumont <alfredo.beaumont@gmail.com>"
+  "Hannes Mehnert <hannes@mehnert.org>"
+]
+authors: [
+  "Alfredo Beaumont <alfredo.beaumont@gmail.com>"
+  "Sonia Meruelo <smeruelo@gmail.com>"
+  "Hannes Mehnert <hannes@mehnert.org>"
+]
+license: "BSD-2-Clause"
+homepage: "https://github.com/robur-coop/kdf"
+doc: "https://robur-coop.github.io/kdf/doc"
+bug-reports: "https://github.com/robur-coop/kdf/issues"
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "1.8.0"}
+  "digestif" {>= "1.2.0"}
+  "mirage-crypto" {>= "1.0.0"}
+  "alcotest" {with-test & >= "0.8.1"}
+  "ohex" {with-test & >= "0.2.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/robur-coop/kdf.git"
+url {
+  src:
+    "https://github.com/robur-coop/kdf/releases/download/v1.0.0/kdf-1.0.0.tbz"
+  checksum: [
+    "sha256=d161582b0efe66d958dd6b8c9c21068e9f6454ce218377d6cf87823dec62e0ce"
+    "sha512=8c518494a7c2e030c079a22fc0d27e4dccd1b2d6edb8fcd2ee7121cdd3d56ff416a37876b6bb13b8be015922c3487536038373bfa0934a165055c1cb5dd3c2e1"
+  ]
+}
+x-commit-hash: "a6da77f39fd1b3acc6865a9a20dca567a5e1fe89"
+x-maintenance-intent: ["(latest)"]

--- a/packages/mirage-crypto-ec/mirage-crypto-ec.2.0.1/opam
+++ b/packages/mirage-crypto-ec/mirage-crypto-ec.2.0.1/opam
@@ -1,12 +1,12 @@
 opam-version: "2.0"
 name: "mirage-crypto-ec"
-version: "0.11.3"
+version: "2.0.1"
 synopsis: "Elliptic Curve Cryptography with primitives taken from Fiat"
 description: """\
 An implementation of key exchange (ECDH) and digital signature (ECDSA/EdDSA)
 algorithms using code from Fiat (<https://github.com/mit-plv/fiat-crypto>).
 
-The curves P224 (SECP224R1), P256 (SECP256R1), P384 (SECP384R1),
+The curves P256 (SECP256R1), P384 (SECP384R1),
 P521 (SECP521R1), and 25519 (X25519, Ed25519) are implemented by this package."""
 maintainer: "Hannes Mehnert <hannes@mehnert.org>"
 authors: [
@@ -14,6 +14,7 @@ authors: [
   "Nathan Rebours <nathan.p.rebours@gmail.com>"
   "Clément Pascutto <clement@tarides.com>"
   "Etienne Millon <me@emillon.org>"
+  "Virgile Robles <virgile.robles@protonmail.ch>"
   "Andres Erbsen <andreser@mit.edu>"
   "Google Inc."
   "Jade Philipoom <jadep@mit.edu> <jade.philipoom@gmail.com>"
@@ -27,17 +28,18 @@ doc: "https://mirage.github.io/mirage-crypto/doc"
 bug-reports: "https://github.com/mirage/mirage-crypto/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" {>= "4.08.0"}
-  "cstruct" {>= "6.0.0"}
+  "ocaml" {>= "4.13.0"}
   "dune-configurator"
   "eqaf" {>= "0.7"}
-  "mirage-crypto" {= version}
   "mirage-crypto-rng" {= version}
-  "hex" {with-test}
+  "digestif" {>= "1.2.0"}
   "alcotest" {with-test & >= "0.8.1"}
   "ppx_deriving_yojson" {with-test}
   "ppx_deriving" {with-test}
   "yojson" {with-test & >= "1.6.0"}
+  "asn1-combinators" {with-test & >= "0.3.1"}
+  "ohex" {with-test & >= "0.2.0"}
+  "ounit2" {with-test}
 ]
 conflicts: ["ocaml-freestanding"]
 build: [
@@ -48,10 +50,11 @@ build: [
 dev-repo: "git+https://github.com/mirage/mirage-crypto.git"
 url {
   src:
-    "https://github.com/mirage/mirage-crypto/releases/download/v0.11.3/mirage-crypto-0.11.3.tbz"
+    "https://github.com/mirage/mirage-crypto/releases/download/v2.0.1/mirage-crypto-2.0.1.tbz"
   checksum: [
-    "sha256=bfb530fa169cd905ebc7e2449f3407cfbd67023ac0b291b8b6f4a1437a5d95b1"
-    "sha512=7b6f4e8128622b53eb2176881b5d6160f224e8606c7dd21aaf47974f15db7aa475cffaff3214aaaabba0f8986398f159c1fbb1bff29228c9b0a3fae67ef8d731"
+    "sha256=5430ce3c3e40627d2d67a8decf565a1f612d39bdb33f9b767c3bdb601ff5a196"
+    "sha512=de029e01cbb8d49f9b8fbcd02ef4777435927118c9ce7a859a8193fdbec30d1a7b3a2964ee8ec722f5fa74fec1bfdc054dcdc97ad1db6e2ced359d6c010c043a"
   ]
 }
-x-commit-hash: "3ebc0e3e1bb6c471292b9f0c18afa3ce20d5f051"
+x-commit-hash: "451538dd395958a038880aaa7c13b23ccf28fae6"
+x-maintenance-intent: ["(latest)"]

--- a/packages/mirage-crypto-pk/mirage-crypto-pk.2.0.1/opam
+++ b/packages/mirage-crypto-pk/mirage-crypto-pk.2.0.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "mirage-crypto-pk"
-version: "0.11.3"
+version: "2.0.1"
 synopsis: "Simple public-key cryptography for the modern age"
 description:
   "Mirage-crypto-pk provides public-key cryptography (RSA, DSA, DH)."
@@ -14,15 +14,15 @@ doc: "https://mirage.github.io/mirage-crypto/doc"
 bug-reports: "https://github.com/mirage/mirage-crypto/issues"
 depends: [
   "conf-gmp-powm-sec" {build}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.13.0"}
   "dune" {>= "2.7"}
   "ounit2" {with-test}
-  "randomconv" {with-test & >= "0.1.3" & < "0.2.0"}
-  "cstruct" {>= "6.00"}
+  "randomconv" {with-test & >= "0.2.0"}
+  "ohex" {with-test & >= "0.2.0"}
   "mirage-crypto" {= version}
   "mirage-crypto-rng" {= version}
-  "sexplib0"
-  "zarith" {>= "1.4"}
+  "digestif" {>= "1.2.0"}
+  "zarith" {>= "1.13"}
   "eqaf" {>= "0.8"}
 ]
 conflicts: ["ocaml-freestanding"]
@@ -34,10 +34,11 @@ build: [
 dev-repo: "git+https://github.com/mirage/mirage-crypto.git"
 url {
   src:
-    "https://github.com/mirage/mirage-crypto/releases/download/v0.11.3/mirage-crypto-0.11.3.tbz"
+    "https://github.com/mirage/mirage-crypto/releases/download/v2.0.1/mirage-crypto-2.0.1.tbz"
   checksum: [
-    "sha256=bfb530fa169cd905ebc7e2449f3407cfbd67023ac0b291b8b6f4a1437a5d95b1"
-    "sha512=7b6f4e8128622b53eb2176881b5d6160f224e8606c7dd21aaf47974f15db7aa475cffaff3214aaaabba0f8986398f159c1fbb1bff29228c9b0a3fae67ef8d731"
+    "sha256=5430ce3c3e40627d2d67a8decf565a1f612d39bdb33f9b767c3bdb601ff5a196"
+    "sha512=de029e01cbb8d49f9b8fbcd02ef4777435927118c9ce7a859a8193fdbec30d1a7b3a2964ee8ec722f5fa74fec1bfdc054dcdc97ad1db6e2ced359d6c010c043a"
   ]
 }
-x-commit-hash: "3ebc0e3e1bb6c471292b9f0c18afa3ce20d5f051"
+x-commit-hash: "451538dd395958a038880aaa7c13b23ccf28fae6"
+x-maintenance-intent: ["(latest)"]

--- a/packages/mirage-crypto-rng/mirage-crypto-rng.2.0.1/opam
+++ b/packages/mirage-crypto-rng/mirage-crypto-rng.2.0.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "mirage-crypto-rng"
-version: "0.11.3"
+version: "2.0.1"
 synopsis: "A cryptographically secure PRNG"
 description: """\
 Mirage-crypto-rng provides a random number generator interface, and
@@ -15,15 +15,16 @@ homepage: "https://github.com/mirage/mirage-crypto"
 doc: "https://mirage.github.io/mirage-crypto/doc"
 bug-reports: "https://github.com/mirage/mirage-crypto/issues"
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.14.0"}
   "dune" {>= "2.7"}
   "dune-configurator" {>= "2.0.0"}
   "duration"
-  "cstruct" {>= "6.0.0"}
   "logs"
   "mirage-crypto" {= version}
+  "digestif" {>= "1.1.4"}
   "ounit2" {with-test}
-  "randomconv" {with-test & >= "0.1.3" & < "0.2.0"}
+  "randomconv" {with-test & >= "0.2.0"}
+  "ohex" {with-test & >= "0.2.0"}
 ]
 conflicts: [
   "mirage-runtime" {< "3.8.0"}
@@ -36,10 +37,11 @@ build: [
 dev-repo: "git+https://github.com/mirage/mirage-crypto.git"
 url {
   src:
-    "https://github.com/mirage/mirage-crypto/releases/download/v0.11.3/mirage-crypto-0.11.3.tbz"
+    "https://github.com/mirage/mirage-crypto/releases/download/v2.0.1/mirage-crypto-2.0.1.tbz"
   checksum: [
-    "sha256=bfb530fa169cd905ebc7e2449f3407cfbd67023ac0b291b8b6f4a1437a5d95b1"
-    "sha512=7b6f4e8128622b53eb2176881b5d6160f224e8606c7dd21aaf47974f15db7aa475cffaff3214aaaabba0f8986398f159c1fbb1bff29228c9b0a3fae67ef8d731"
+    "sha256=5430ce3c3e40627d2d67a8decf565a1f612d39bdb33f9b767c3bdb601ff5a196"
+    "sha512=de029e01cbb8d49f9b8fbcd02ef4777435927118c9ce7a859a8193fdbec30d1a7b3a2964ee8ec722f5fa74fec1bfdc054dcdc97ad1db6e2ced359d6c010c043a"
   ]
 }
-x-commit-hash: "3ebc0e3e1bb6c471292b9f0c18afa3ce20d5f051"
+x-commit-hash: "451538dd395958a038880aaa7c13b23ccf28fae6"
+x-maintenance-intent: ["(latest)"]

--- a/packages/mirage-crypto/mirage-crypto.2.0.1/opam
+++ b/packages/mirage-crypto/mirage-crypto.2.0.1/opam
@@ -1,10 +1,9 @@
 opam-version: "2.0"
 name: "mirage-crypto"
-version: "0.11.3"
+version: "2.0.1"
 synopsis: "Simple symmetric cryptography for the modern age"
-description: """\
-Mirage-crypto provides symmetric ciphers (DES, AES, RC4, ChaCha20/Poly1305), and
-hashes (MD5, SHA-1, SHA-2)."""
+description:
+  "Mirage-crypto provides symmetric ciphers (DES, AES, RC4, ChaCha20/Poly1305)."
 maintainer: "Hannes Mehnert <hannes@mehnert.org>"
 authors: [
   "David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>"
@@ -14,12 +13,12 @@ homepage: "https://github.com/mirage/mirage-crypto"
 doc: "https://mirage.github.io/mirage-crypto/doc"
 bug-reports: "https://github.com/mirage/mirage-crypto/issues"
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.13.0"}
   "dune" {>= "2.7"}
   "dune-configurator" {>= "2.0.0"}
   "ounit2" {with-test}
-  "cstruct" {>= "6.0.0"}
-  "eqaf" {>= "0.8" & < "0.10"}
+  "ohex" {with-test & >= "0.2.0"}
+  "eqaf" {>= "0.8"}
 ]
 conflicts: [
   "ocaml-freestanding"
@@ -33,10 +32,11 @@ build: [
 dev-repo: "git+https://github.com/mirage/mirage-crypto.git"
 url {
   src:
-    "https://github.com/mirage/mirage-crypto/releases/download/v0.11.3/mirage-crypto-0.11.3.tbz"
+    "https://github.com/mirage/mirage-crypto/releases/download/v2.0.1/mirage-crypto-2.0.1.tbz"
   checksum: [
-    "sha256=bfb530fa169cd905ebc7e2449f3407cfbd67023ac0b291b8b6f4a1437a5d95b1"
-    "sha512=7b6f4e8128622b53eb2176881b5d6160f224e8606c7dd21aaf47974f15db7aa475cffaff3214aaaabba0f8986398f159c1fbb1bff29228c9b0a3fae67ef8d731"
+    "sha256=5430ce3c3e40627d2d67a8decf565a1f612d39bdb33f9b767c3bdb601ff5a196"
+    "sha512=de029e01cbb8d49f9b8fbcd02ef4777435927118c9ce7a859a8193fdbec30d1a7b3a2964ee8ec722f5fa74fec1bfdc054dcdc97ad1db6e2ced359d6c010c043a"
   ]
 }
-x-commit-hash: "3ebc0e3e1bb6c471292b9f0c18afa3ce20d5f051"
+x-commit-hash: "451538dd395958a038880aaa7c13b23ccf28fae6"
+x-maintenance-intent: ["(latest)"]

--- a/packages/ohex/ohex.0.2.0/opam
+++ b/packages/ohex/ohex.0.2.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+name: "ohex"
+version: "0.2.0"
+synopsis: "Hexadecimal encoding and decoding"
+description: "A library to encode and decode hexadecimal byte sequences."
+maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+authors: "Hannes Mehnert <hannes@mehnert.org>"
+license: "BSD-2-Clause"
+homepage: "https://git.robur.coop/robur/ohex"
+doc: "https://robur-coop.github.io/ohex/doc"
+bug-reports: "https://git.robur.coop/robur/ohex/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.7"}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://git.robur.coop/robur/ohex.git"
+url {
+  src:
+    "https://github.com/ocaml/opam-source-archives/raw/main/ohex-0.2.0.tar.gz"
+  checksum: [
+    "md5=77f2cbe75b9efd528a2b3478a8d4f3d4"
+    "sha512=af72a9699f81878cc7d247a92a28332a8e34f247ad6bd477f8c7ae7f2970b73c4750a31eedf8eeb43ca8d19ae3c4c4f8a9d5421a40b73eb1f1711f44b14ff3e6"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/x509/x509.1.0.6/opam
+++ b/packages/x509/x509.1.0.6/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "x509"
-version: "0.16.5"
+version: "1.0.6"
 synopsis: "Public Key Infrastructure (RFC 5280, PKCS) purely in OCaml"
 description: """\
 X.509 is a public key infrastructure used mostly on the Internet.  It consists
@@ -20,24 +20,23 @@ homepage: "https://github.com/mirleft/ocaml-x509"
 doc: "https://mirleft.github.io/ocaml-x509/doc"
 bug-reports: "https://github.com/mirleft/ocaml-x509/issues"
 depends: [
-  "ocaml" {>= "4.08.0"}
-  "dune" {>= "1.2"}
-  "cstruct" {>= "6.0.0"}
-  "asn1-combinators" {>= "0.2.0" & < "0.3.0"}
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "2.0"}
+  "asn1-combinators" {>= "0.3.1"}
   "ptime"
   "base64" {>= "3.3.0"}
-  "mirage-crypto" {< "1.0.0"}
-  "mirage-crypto-pk" {< "1.0.0"}
-  "mirage-crypto-ec" {>= "0.10.7" & < "1.0.0"}
-  "mirage-crypto-rng" {< "1.0.0"}
-  "mirage-crypto-rng" {with-test & >= "0.11.0" & < "1.0.0"}
+  "mirage-crypto" {>= "1.0.0"}
+  "mirage-crypto-pk"
+  "mirage-crypto-ec" {>= "0.10.7"}
+  "mirage-crypto-rng"
+  "mirage-crypto-rng" {with-test & >= "1.2.0"}
   "fmt" {>= "0.8.7"}
   "alcotest" {with-test}
-  "cstruct-unix" {with-test & >= "3.0.0"}
   "gmap" {>= "0.3.0"}
   "domain-name" {>= "0.3.0"}
   "logs"
-  "pbkdf"
+  "kdf" {>= "1.0.0"}
+  "ohex" {>= "0.2.0"}
   "ipaddr" {>= "5.2.0"}
 ]
 conflicts: [
@@ -51,10 +50,11 @@ build: [
 dev-repo: "git+https://github.com/mirleft/ocaml-x509.git"
 url {
   src:
-    "https://github.com/mirleft/ocaml-x509/releases/download/v0.16.5/x509-0.16.5.tbz"
+    "https://github.com/mirleft/ocaml-x509/releases/download/v1.0.6/x509-1.0.6.tbz"
   checksum: [
-    "sha256=149e25a5fea37f619fb2690bee5c00f01c9dcf31d335f8ffcaab39a7538ccd99"
-    "sha512=6dd494dba799eab7edde2af1b63bac6035bf4ae06f3a36dd4fa9abcd13d0c3fe3e93dc5848b65405dc5401b1755fd30c71482cb91f7495bc9cfb7c5bf15ef6d7"
+    "sha256=fc816ae2c65e8b42fa60d90a507b2140495e28d095ad37b27e4c268ae3c00d6c"
+    "sha512=3ca30aa78366cbb0599cce69a7bbfeaf857cc885f1367f3cf62d4236a55b40172478b73bda70c38b658dcfe9e407326f8db0a260cb36b568e3063c6eb75e0bd7"
   ]
 }
-x-commit-hash: "b00656d2952282323604765d504dfea067b17879"
+x-commit-hash: "af4ab13517c5138161eb11492c7c7acb1b34fe1a"
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
BREAKING: replaces cstructs for strings, and changes rng generators' API

matching xapi branch is at https://github.com/xapi-project/xen-api/compare/master...psafont:xen-api:private/paus/stringy-crypto