### PR TITLE
Add `qcow-stream` and its dependencies

### DIFF
--- a/packages/asetmap/asetmap.0.8.1/opam
+++ b/packages/asetmap/asetmap.0.8.1/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "http://erratique.ch/software/asetmap"
+doc: "http://erratique.ch/software/asetmap/doc"
+license: "ISC"
+dev-repo: "git+http://erratique.ch/repos/asetmap.git"
+bug-reports: "https://github.com/dbuenzli/asetmap/issues"
+tags: [ "org:erratique" "set" "map" "stdlib" ]
+depends: [
+  "ocaml" {>= "4.01.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+]
+build: [
+  "ocaml" "pkg/pkg.ml" "build"
+          "--pinned" "%{pinned}%" ]
+synopsis: "Alternative, compatible, OCaml standard library Sets and Maps"
+description: """
+asetmap provides slightly tweaked OCaml standard library Set and Map
+functors. asetmap tries to maximize compatibility with the standard
+library. It essentially gets rid of `Not_found` exceptions and provide
+pretty-printers for the data types.
+
+asetmap has no dependency is distributed under the ISC license."""
+url {
+  src: "http://erratique.ch/software/asetmap/releases/asetmap-0.8.1.tbz"
+  checksum: [
+    "sha256=43211c54671e3c55e73e8ac5e1fb54e168d5c2875c356eb77efc98906c1f53fe"
+    "md5=9e4a518bfb6350e2f296c7f3147989c7"
+  ]
+}
+
+x-maintenance-intent: ["(latest)"]

--- a/packages/prometheus/prometheus.1.2/opam
+++ b/packages/prometheus/prometheus.1.2/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Client library for Prometheus monitoring"
+maintainer: "talex5@gmail.com"
+authors: ["Thomas Leonard" "David Scott"]
+license: "Apache-2.0"
+homepage: "https://github.com/mirage/prometheus"
+doc: "https://mirage.github.io/prometheus/"
+bug-reports: "https://github.com/mirage/prometheus/issues"
+depends: [
+  "ocaml" {>= "4.01.0"}
+  "dune" {>= "2.3"}
+  "astring"
+  "asetmap"
+  "re"
+  "lwt" {>= "2.5.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/prometheus.git"
+description: """
+To run services reliably, it is useful if they can report various metrics
+(for example, heap size, queue lengths, number of warnings logged, etc).
+
+A monitoring service can be configured to collect this data regularly.
+The data can be graphed to help understand the performance of the service over time,
+or to help debug problems quickly.
+It can also be used to send alerts if a service is down or behaving poorly.
+"""
+url {
+  src:
+    "https://github.com/mirage/prometheus/releases/download/v1.2/prometheus-1.2.tbz"
+  checksum: [
+    "sha256=83643a029a6b6de71d14034eee2e94feff1d08755c4a41d583dc1530ab555bcb"
+    "sha512=bbec7f0728b850b991ec50e76ef2c999341a9469ceaa11b68180f060150c4fe62f3dca87c13914ac331b3d7ef6e46256ae11466b607ecb60d00b8f284cab86b9"
+  ]
+}
+x-commit-hash: "d1669d0e0d7e44b104755a0fd9700ae87e140f34"

--- a/packages/qcow-stream/qcow-stream.0.12.1/opam
+++ b/packages/qcow-stream/qcow-stream.0.12.1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Library offering QCOW streaming capabilities"
+maintainer: [
+  "Dave Scott <dave@recoil.org>" "Pau Ruiz Safont" "Edwin Török "
+]
+authors: ["David Scott"]
+license: "ISC"
+tags: ["org:mirage"]
+homepage: "https://github.com/mirage/ocaml-qcow"
+bug-reports: "https://github.com/mirage/ocaml-qcow/issues"
+depends: [
+  "dune" {>= "3.18"}
+  "qcow-types" {= version}
+  "cstruct-lwt"
+  "io-page"
+  "lwt" {>= "5.5.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-qcow.git"
+x-maintenance-intent: ["latest"]
+url {
+  src:
+    "https://github.com/mirage/ocaml-qcow/releases/download/0.12.1/qcow-0.12.1.tbz"
+  checksum: [
+    "sha256=c799f3c2eda00b345d37ccd759bcd7b8be8744216b77a38883ff4cd99727ae37"
+    "sha512=2160598f460240f9580991e7f7d69e3ef83a2e6ec62268b711840d359cd303d4e14a5d65d89ceb82a6f77b434d06a01af9daa7780808a885f3307909c11dcfd8"
+  ]
+}
+x-commit-hash: "e9f228b3626aef9275c43f539bb9959d8d167314"

--- a/packages/qcow-types/qcow-types.0.12.1/opam
+++ b/packages/qcow-types/qcow-types.0.12.1/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Minimal set of dependencies for qcow-stream, shared with qcow"
+maintainer: [
+  "Dave Scott <dave@recoil.org>" "Pau Ruiz Safont" "Edwin Török "
+]
+authors: ["David Scott"]
+license: "ISC"
+tags: ["org:mirage"]
+homepage: "https://github.com/mirage/ocaml-qcow"
+bug-reports: "https://github.com/mirage/ocaml-qcow/issues"
+depends: [
+  "dune" {>= "3.18"}
+  "ocaml" {>= "4.12.0"}
+  "astring"
+  "cstruct" {>= "6.1.0"}
+  "logs"
+  "lwt"
+  "mirage-block" {>= "3.0.0"}
+  "ppx_sexp_conv"
+  "prometheus"
+  "sexplib"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-qcow.git"
+x-maintenance-intent: ["latest"]
+url {
+  src:
+    "https://github.com/mirage/ocaml-qcow/releases/download/0.12.1/qcow-0.12.1.tbz"
+  checksum: [
+    "sha256=c799f3c2eda00b345d37ccd759bcd7b8be8744216b77a38883ff4cd99727ae37"
+    "sha512=2160598f460240f9580991e7f7d69e3ef83a2e6ec62268b711840d359cd303d4e14a5d65d89ceb82a6f77b434d06a01af9daa7780808a885f3307909c11dcfd8"
+  ]
+}
+x-commit-hash: "e9f228b3626aef9275c43f539bb9959d8d167314"

--- a/packages/xapi/xapi.master/opam
+++ b/packages/xapi/xapi.master/opam
@@ -50,6 +50,7 @@ depends: [
   "ppx_deriving"
   "psq"
   "ptime"
+  "qcow-stream"
   "qcheck-alcotest"
   "qcheck-core"
   "re"


### PR DESCRIPTION
Adds a library offering QCOW streaming import (that will be used in xapi's vdi-import) and its dependencies.