### PR TITLE
packages: limit ocamlformat 0.27.0 to ocaml 5

### DIFF
--- a/packages/ocamlformat/ocamlformat.0.27.0/opam
+++ b/packages/ocamlformat/ocamlformat.0.27.0/opam
@@ -25,7 +25,7 @@ license: ["MIT" "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"]
 homepage: "https://github.com/ocaml-ppx/ocamlformat"
 bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
 depends: [
-  "ocaml" {>= "4.08" & < "5.4"}
+  "ocaml" {>= "5.0" & < "5.4"}
   "cmdliner" {with-test = "false" & >= "1.1.0" | with-test & >= "1.2.0"}
   "csexp" {>= "1.4.0"}
   "dune" {>= "2.8"}


### PR DESCRIPTION
This is done to avoid changing the formatting on xapi while still allowing compilation of all the tools in ocaml 5 for the rpms.

With the PR ocamlformat 0.26.2 is installed when using ocaml 4.14: https://github.com/xapi-project/xs-opam/actions/runs/17910307744/job/50920143220?pr=739#step:11:146