### PR TITLE
Makefile: Be explicit about retaining the base packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,11 @@ archive: $(NAME).tar.gz
 
 $(NAME).tar.gz:
 	# Remove unneeded packages (like dev tools), and retain special packages
-	opam admin filter --recursive --required-by xs-toolstack --or host-system-other -y
+	# the base packages are a postinstall dependency of the compilers, and need
+	# to be explicitly included
+	opam admin filter --recursive --or -y --required-by \
+		xs-toolstack host-system-other \
+		base-bigarray base-bytes base-domains base-nnp base-threads base-unix
 	# Remove all xapi dev packages
 	opam admin filter '*.master' --remove -y
 	# Remove compilable ocaml versions


### PR DESCRIPTION
Historically all of them have been required by some package, other than the compiler. This is not the case for base-domains and base-nnp. It's time to be explicit about them.

I've manually built the tarball, in a 4.14 and a 5.3 switch, and inspected the contents:
```
$ tar -tf  xs-opam-repo-6.93.0-2-g3c83860c.tar.gz | grep base-domains
xs-opam-repo-6.93.0-2-g3c83860c/packages/base-domains/
xs-opam-repo-6.93.0-2-g3c83860c/packages/base-domains/base-domains.base/
xs-opam-repo-6.93.0-2-g3c83860c/packages/base-domains/base-domains.base/opam
```