### PR TITLE
Remove ocaml-compiler package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ $(NAME).tar.gz:
 	# Remove all xapi dev packages
 	opam admin filter '*.master' --remove -y
 	# Remove compilable ocaml versions
-	opam admin filter 'ocaml-base-compiler' --remove -y
+	opam admin filter --or 'ocaml-base-compiler' 'ocaml-compiler' --remove -y
 	# Remove xen-related packages, the libraries are built by the xen package
 	opam admin filter 'conf-xen' --remove -y
 	opam admin cache |& tee cache.log


### PR DESCRIPTION
This caused the compiler binaries to be installed in the opamroot even when using ocaml-system. This led to inconsistencies in builds on top of xs-opam (xapi).