### PR TITLE
Update ocaml-qcow to 0.14.0

### DIFF
--- a/packages/conf-qemu-img/conf-qemu-img.1/opam
+++ b/packages/conf-qemu-img/conf-qemu-img.1/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+maintainer: "https://github.com/ocaml/opam-repository/issues"
+homepage: "https://gitlab.com/qemu-project/qemu/"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+authors: "Fabrice Bellard and the QEMU team"
+license: "GPL-2.0-only"
+build: ["qemu-img" "--version"]
+depexts: [
+  ["qemu-utils"] {os-family = "debian"}
+  ["qemu-utils"] {os-family = "ubuntu"}
+  ["qemu-img"] {os-family = "fedora"}
+  ["qemu-img"] {os-distribution = "rhel"}
+  ["epel-release" "qemu-img"] {os-distribution = "centos"}
+  ["qemu-img"] {os-distribution = "alpine"}
+  ["qemu-img"] {os-family = "suse" | os-family = "opensuse"}
+  ["qemu-img"] {os-distribution = "arch"}
+  ["qemu"] {os = "macos" & os-distribution = "homebrew"}
+  ["qemu"] {os = "freebsd"}
+]
+synopsis: "Virtual package relying on qemu-img"
+description:
+  "This package can only install if the qemu-img binary is installed on the system."
+flags: conf

--- a/packages/lwt_ppx/lwt_ppx.5.9.1/opam
+++ b/packages/lwt_ppx/lwt_ppx.5.9.1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+name: "lwt_ppx"
+version: "5.9.1"
+synopsis: "PPX syntax for Lwt, providing something similar to async/await from JavaScript"
+maintainer: [
+  "Raphaël Proust <code@bnwr.net>" "Anton Bachin <antonbachin@yahoo.com>"
+]
+authors: ["Jérôme Vouillon" "Jérémie Dimino"]
+license: "MIT"
+homepage: "https://github.com/ocsigen/lwt"
+doc: "https://ocsigen.org/lwt"
+bug-reports: "https://github.com/ocsigen/lwt/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08"}
+  "ppxlib" {>= "0.16.0" & < "0.36"}
+  "ppx_let" {with-test}
+  "lwt" {>= "5.7.0" & < "6~"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocsigen/lwt.git"
+url {
+  src: "https://github.com/ocsigen/lwt/archive/refs/tags/5.9.1.tar.gz"
+  checksum: [
+    "md5=18742da8b8fe3618e3fa700b7a884fe7"
+    "sha512=1c51fdb4d0856c89e2df08a1c0095ef28ebd0f613b07b03d0f66501ca5486515562071291e6d0932e57587ed0c9362c8b92c5c9eddb4d2bb2f5e129986b484a7"
+  ]
+}

--- a/packages/qcow-stream/qcow-stream.0.14.0/opam
+++ b/packages/qcow-stream/qcow-stream.0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "qcow-stream"
-version: "0.12.2"
+version: "0.14.0"
 synopsis: "Library offering QCOW streaming capabilities"
 maintainer: [
   "Dave Scott <dave@recoil.org>" "Pau Ruiz Safont" "Edwin Török "
@@ -12,10 +12,13 @@ homepage: "https://github.com/mirage/ocaml-qcow"
 bug-reports: "https://github.com/mirage/ocaml-qcow/issues"
 depends: [
   "dune" {>= "3.18"}
+  "ocaml" {>= "4.12.0"}
+  "alcotest" {with-test & >= "1.2.0"}
   "qcow-types" {= version}
   "cstruct-lwt"
   "io-page"
   "lwt" {>= "5.5.0"}
+  "lwt_ppx" {>= "2.0.3"}
   "odoc" {with-doc}
 ]
 build: [
@@ -30,13 +33,13 @@ build: [
   "@doc" {with-doc}
 ]
 dev-repo: "git+https://github.com/mirage/ocaml-qcow.git"
+x-maintenance-intent: ["latest"]
 url {
   src:
-    "https://github.com/mirage/ocaml-qcow/releases/download/0.12.2/qcow-0.12.2.tbz"
+    "https://github.com/mirage/ocaml-qcow/releases/download/0.14.0/qcow-0.14.0.tbz"
   checksum: [
-    "sha256=bb12f9f37ad69b54af000e64add460034ea09102687aacb4f748488afe83c868"
-    "sha512=883fc7a1d98ee1c272408829050a0b56c785664bc16c0820440d638039e08e55c458813728c2f8c8ac49ceea582a79c3d93142664d5134f87e6bb6618a6b8f66"
+    "sha256=0c7845059853675ae99bf0d1463670f81af4e84131f9c871e0cc5e813fb53504"
+    "sha512=5bb14b6a1ca355f09fc800692ba97590c6d653823b4df951a11c3bfd83c574b41364e32b124738c219bbb5d11af3ea04d7b69afe9562f5112c2cb6b6834e77d1"
   ]
 }
-x-commit-hash: "b7fc9dfd4b071b49eebbfdf7401551eb305bda01"
-x-maintenance-intent: ["(latest)"]
+x-commit-hash: "1eacfe0af61f1743ea17aecf96901fdb70304b85"

--- a/packages/qcow-types/qcow-types.0.14.0/opam
+++ b/packages/qcow-types/qcow-types.0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "qcow-types"
-version: "0.12.2"
+version: "0.14.0"
 synopsis: "Minimal set of dependencies for qcow-stream, shared with qcow"
 maintainer: [
   "Dave Scott <dave@recoil.org>" "Pau Ruiz Safont" "Edwin Török "
@@ -18,6 +18,7 @@ depends: [
   "diet" {>= "0.3.0"}
   "logs"
   "lwt"
+  "lwt_ppx" {>= "1.0.1"}
   "mirage-block" {>= "3.0.0"}
   "ppx_sexp_conv"
   "prometheus"
@@ -36,13 +37,13 @@ build: [
   "@doc" {with-doc}
 ]
 dev-repo: "git+https://github.com/mirage/ocaml-qcow.git"
+x-maintenance-intent: ["latest"]
 url {
   src:
-    "https://github.com/mirage/ocaml-qcow/releases/download/0.12.2/qcow-0.12.2.tbz"
+    "https://github.com/mirage/ocaml-qcow/releases/download/0.14.0/qcow-0.14.0.tbz"
   checksum: [
-    "sha256=bb12f9f37ad69b54af000e64add460034ea09102687aacb4f748488afe83c868"
-    "sha512=883fc7a1d98ee1c272408829050a0b56c785664bc16c0820440d638039e08e55c458813728c2f8c8ac49ceea582a79c3d93142664d5134f87e6bb6618a6b8f66"
+    "sha256=0c7845059853675ae99bf0d1463670f81af4e84131f9c871e0cc5e813fb53504"
+    "sha512=5bb14b6a1ca355f09fc800692ba97590c6d653823b4df951a11c3bfd83c574b41364e32b124738c219bbb5d11af3ea04d7b69afe9562f5112c2cb6b6834e77d1"
   ]
 }
-x-commit-hash: "b7fc9dfd4b071b49eebbfdf7401551eb305bda01"
-x-maintenance-intent: ["(latest)"]
+x-commit-hash: "1eacfe0af61f1743ea17aecf96901fdb70304b85"

--- a/packages/vhd-tool/vhd-tool.26.1-lcm/opam
+++ b/packages/vhd-tool/vhd-tool.26.1-lcm/opam
@@ -16,6 +16,7 @@ depends: [
   "cohttp"
   "cohttp-lwt"
   "conf-libssl"
+  "conf-qemu-img" {with-test}
   "cstruct" {>= "3.0.0"}
   "ezxenstore" {= version}
   "forkexec" {= version}


### PR DESCRIPTION
Breaking changes to the interface, with the allocated data clusters now returned in `Qcow_mapping.t`. Great reductions in memory usage, various other optimizations.

Needs to be merged together with https://github.com/xapi-project/xen-api/pull/6895