### PR TITLE
packages: update xapi-backtrace to 0.8 (6.99 LCM)

### DIFF
--- a/packages/xapi-backtrace/xapi-backtrace.0.8/opam
+++ b/packages/xapi-backtrace/xapi-backtrace.0.8/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "xapi-backtrace"
-version: "0.7"
+version: "0.8"
 synopsis: "A simple library for recording and managing backtraces"
 description: """\
 This allows backtraces from multiple processes to be combined together
@@ -13,18 +13,23 @@ homepage: "https://github.com/xapi-project/backtrace"
 bug-reports: "https://github.com/xapi-project/backtrace/issues"
 depends: [
   "ocaml"
-  "dune" {>= "1.4"}
+  "dune" {>= "2.7"}
   "base-threads"
   "ppx_deriving_rpc"
   "ppx_sexp_conv" {>= "v0.11.0"}
   "rpclib"
 ]
-build: ["dune" "build" "-p" name "-j" jobs]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
 dev-repo: "git+https://github.com/xapi-project/backtrace.git"
 url {
-  src: "https://github.com/xapi-project/backtrace/archive/v0.7.tar.gz"
+  src:
+    "https://github.com/xapi-project/backtrace/releases/download/v0.8/xapi-backtrace-0.8.tbz"
   checksum: [
-    "sha256=9a9f7276997cc53e1eaa5739d91ccd790f78c7423b75060331bf3ce44f5ac1ea"
-    "md5=0c62a615ae48504e4de2c5d62ab344b5"
+    "sha256=f4ccdde88d09e9c20c37830935347a8616a23aeb406a8c3a7264ce5d84502843"
+    "sha512=cb3f4bd704e63797001c2b8945a31ae770aa82969b1e7f2e17e16fe7d05d9ddca0a2ef8861c81b8672d18cdbcabcadd8582502928820e8fd6f9c3743fb95f219"
   ]
 }
+x-commit-hash: "bedc68d478e75f46ca38c83404a757ae54b6bb55"


### PR DESCRIPTION
minor: contains fixes for reraise and with_backtraces

(cherry picked from commit 68880932fa34fe7c1e801232d71330e1d6f27464)