### PR TITLE
github: build releases for tags in branch 6.99-lcm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,38 @@
+name: Create release from tag
+
+on:
+  push:
+    tags:
+      # matches 6.99.0 through 6.99.99, allowing for suffixes
+      - '6.99.[0-9][0-9]?*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Install opam
+      uses: ocaml/setup-ocaml@v3
+      with:
+        ocaml-compiler: "4.14.2"
+        opam-repositories: |
+          xs-opam: "."
+        opam-pin: false
+        dune-cache: true
+        allow-prerelease-opam: true
+
+    - name: Collect licenses
+      run: ./tools/print-licenses.sh > licenses.txt
+
+    - name: Archive upstream libraries
+      run: make archive
+
+    - name: Create Release ${{ github.ref_name }}
+      run: |
+        gh release create ${{ github.ref_name }} --repo ${{ github.repository }} --generate-notes \
+           licenses.txt xs-opam-repo-${{ github.ref_name }}.tar.gz
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The workflow in the master branch that creates releases is only triggered for tags present in the master branch, add the workflow to the master branch to make sure we don't miss more releases.