### PR TITLE
[master] Update ocaml-qcow to 0.14.0

### DIFF
--- a/packages/lwt_ppx/lwt_ppx.5.9.1/opam
+++ b/packages/lwt_ppx/lwt_ppx.5.9.1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+name: "lwt_ppx"
+version: "5.9.1"
+synopsis: "PPX syntax for Lwt, providing something similar to async/await from JavaScript"
+maintainer: [
+  "Raphaël Proust <code@bnwr.net>" "Anton Bachin <antonbachin@yahoo.com>"
+]
+authors: ["Jérôme Vouillon" "Jérémie Dimino"]
+license: "MIT"
+homepage: "https://github.com/ocsigen/lwt"
+doc: "https://ocsigen.org/lwt"
+bug-reports: "https://github.com/ocsigen/lwt/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08"}
+  "ppxlib" {>= "0.16.0" & < "0.36"}
+  "ppx_let" {with-test}
+  "lwt" {>= "5.7.0" & < "6~"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocsigen/lwt.git"
+url {
+  src: "https://github.com/ocsigen/lwt/archive/refs/tags/5.9.1.tar.gz"
+  checksum: [
+    "md5=18742da8b8fe3618e3fa700b7a884fe7"
+    "sha512=1c51fdb4d0856c89e2df08a1c0095ef28ebd0f613b07b03d0f66501ca5486515562071291e6d0932e57587ed0c9362c8b92c5c9eddb4d2bb2f5e129986b484a7"
+  ]
+}

--- a/packages/lwt_ppx/lwt_ppx.5.9.3/opam
+++ b/packages/lwt_ppx/lwt_ppx.5.9.3/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+name: "lwt_ppx"
+version: "5.9.3"
+synopsis: "PPX syntax for Lwt, providing something similar to async/await from JavaScript"
+maintainer: [
+  "Raphaël Proust <code@bnwr.net>" "Anton Bachin <antonbachin@yahoo.com>"
+]
+authors: ["Gabriel Radanne"]
+license: "MIT"
+homepage: "https://github.com/ocsigen/lwt"
+doc: "https://ocsigen.org/lwt"
+bug-reports: "https://github.com/ocsigen/lwt/issues"
+depends: [
+  "dune" {>= "3.15"}
+  "ocaml" {>= "4.08"}
+  "ppxlib" {>= "0.36"}
+  "lwt" {>= "5.7" & < "6.0.0" }
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocsigen/lwt.git"
+url {
+  src: "https://github.com/ocsigen/lwt/archive/refs/tags/5.9.3.tar.gz"
+  checksum: [
+    "md5=c24a86336f721f58bfd01757b4c672fe"
+    "sha512=7f69e2c2e886dc5adef2a9205466823d59a143a5fd65ada8dbdbd2f83961b1cecbf345d20e20181643611a037460283ab92b9505c98093fe4ff28e24cce80edd"
+  ]
+}
+conflicts: [
+	"lwt" {= "6.0.0~alpha00" }
+	"lwt" {= "6.0.0~beta01" }
+]

--- a/packages/qcow-stream/qcow-stream.0.14.0/opam
+++ b/packages/qcow-stream/qcow-stream.0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "qcow-stream"
-version: "0.12.2"
+version: "0.14.0"
 synopsis: "Library offering QCOW streaming capabilities"
 maintainer: [
   "Dave Scott <dave@recoil.org>" "Pau Ruiz Safont" "Edwin Török "
@@ -12,10 +12,13 @@ homepage: "https://github.com/mirage/ocaml-qcow"
 bug-reports: "https://github.com/mirage/ocaml-qcow/issues"
 depends: [
   "dune" {>= "3.18"}
+  "ocaml" {>= "4.12.0"}
+  "alcotest" {with-test & >= "1.2.0"}
   "qcow-types" {= version}
   "cstruct-lwt"
   "io-page"
   "lwt" {>= "5.5.0"}
+  "lwt_ppx" {>= "2.0.3"}
   "odoc" {with-doc}
 ]
 build: [
@@ -30,13 +33,13 @@ build: [
   "@doc" {with-doc}
 ]
 dev-repo: "git+https://github.com/mirage/ocaml-qcow.git"
+x-maintenance-intent: ["latest"]
 url {
   src:
-    "https://github.com/mirage/ocaml-qcow/releases/download/0.12.2/qcow-0.12.2.tbz"
+    "https://github.com/mirage/ocaml-qcow/releases/download/0.14.0/qcow-0.14.0.tbz"
   checksum: [
-    "sha256=bb12f9f37ad69b54af000e64add460034ea09102687aacb4f748488afe83c868"
-    "sha512=883fc7a1d98ee1c272408829050a0b56c785664bc16c0820440d638039e08e55c458813728c2f8c8ac49ceea582a79c3d93142664d5134f87e6bb6618a6b8f66"
+    "sha256=0c7845059853675ae99bf0d1463670f81af4e84131f9c871e0cc5e813fb53504"
+    "sha512=5bb14b6a1ca355f09fc800692ba97590c6d653823b4df951a11c3bfd83c574b41364e32b124738c219bbb5d11af3ea04d7b69afe9562f5112c2cb6b6834e77d1"
   ]
 }
-x-commit-hash: "b7fc9dfd4b071b49eebbfdf7401551eb305bda01"
-x-maintenance-intent: ["(latest)"]
+x-commit-hash: "1eacfe0af61f1743ea17aecf96901fdb70304b85"

--- a/packages/qcow-types/qcow-types.0.14.0/opam
+++ b/packages/qcow-types/qcow-types.0.14.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "qcow-types"
-version: "0.12.2"
+version: "0.14.0"
 synopsis: "Minimal set of dependencies for qcow-stream, shared with qcow"
 maintainer: [
   "Dave Scott <dave@recoil.org>" "Pau Ruiz Safont" "Edwin Török "
@@ -18,6 +18,7 @@ depends: [
   "diet" {>= "0.3.0"}
   "logs"
   "lwt"
+  "lwt_ppx" {>= "1.0.1"}
   "mirage-block" {>= "3.0.0"}
   "ppx_sexp_conv"
   "prometheus"
@@ -36,13 +37,13 @@ build: [
   "@doc" {with-doc}
 ]
 dev-repo: "git+https://github.com/mirage/ocaml-qcow.git"
+x-maintenance-intent: ["latest"]
 url {
   src:
-    "https://github.com/mirage/ocaml-qcow/releases/download/0.12.2/qcow-0.12.2.tbz"
+    "https://github.com/mirage/ocaml-qcow/releases/download/0.14.0/qcow-0.14.0.tbz"
   checksum: [
-    "sha256=bb12f9f37ad69b54af000e64add460034ea09102687aacb4f748488afe83c868"
-    "sha512=883fc7a1d98ee1c272408829050a0b56c785664bc16c0820440d638039e08e55c458813728c2f8c8ac49ceea582a79c3d93142664d5134f87e6bb6618a6b8f66"
+    "sha256=0c7845059853675ae99bf0d1463670f81af4e84131f9c871e0cc5e813fb53504"
+    "sha512=5bb14b6a1ca355f09fc800692ba97590c6d653823b4df951a11c3bfd83c574b41364e32b124738c219bbb5d11af3ea04d7b69afe9562f5112c2cb6b6834e77d1"
   ]
 }
-x-commit-hash: "b7fc9dfd4b071b49eebbfdf7401551eb305bda01"
-x-maintenance-intent: ["(latest)"]
+x-commit-hash: "1eacfe0af61f1743ea17aecf96901fdb70304b85"


### PR DESCRIPTION
This is a forward-port of https://github.com/xapi-project/xs-opam/pull/755 (with the exception of commits later reverted in https://github.com/xapi-project/xs-opam/pull/766).

This PR's CI will fail as xapi hasn't been updated to follow new interfaces yet, so the xapi PR (https://github.com/xapi-project/xen-api/pull/7106) needs to be merged first